### PR TITLE
Exclude provided scope dependencies from runtime.artifacts

### DIFF
--- a/provisio-maven-plugin/src/main/java/io/tesla/maven/plugins/provisio/ProvisioningMojo.java
+++ b/provisio-maven-plugin/src/main/java/io/tesla/maven/plugins/provisio/ProvisioningMojo.java
@@ -147,7 +147,7 @@ public class ProvisioningMojo extends AbstractMojo {
     //
     ArtifactSet artifactSet = new ArtifactSet();
     for (org.apache.maven.artifact.Artifact mavenArtifact : project.getArtifacts()) {
-      if (!mavenArtifact.getScope().equals("system")) {
+      if (!mavenArtifact.getScope().equals("system") && !mavenArtifact.getScope().equals("provided")) {
         artifactSet.addArtifact(new ProvisioArtifact(toArtifact(mavenArtifact)));
       }
     }


### PR DESCRIPTION
Dependencies with provided scope will be provided at runtime by
the container and thus should not be packaged in the artifact.
