### PR TITLE
Rescan configs.

### DIFF
--- a/provisio-jenkins-launcher/src/main/dist/etc/logback.xml
+++ b/provisio-jenkins-launcher/src/main/dist/etc/logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
+<configuration scan="true">
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>
   </contextListener>


### PR DESCRIPTION
Jenkins allows configure JUL loggers, but they doesn't work because of logback and there is no way to change logging and debug application.