### PR TITLE
Manage dependencies in pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Maven-based provisioning mechanism and replacement for the maven-assembly-plug
 - [Support for inserting artifacts into archives on the fly](#feature7)
 - [Support for standard addition of files to a runtime](#feature8)
 - [Support for automatic exclusions in parent/child artifactSet relationships](#feature9)
+- [Support for generating dependencies for pom.xml](#feature10)
 
 Provisio was originally created for the [Presto](https://prestosql.io/) project to provide a common way to build [Presto plugins](https://github.com/prestosql/presto-maven-plugin) and build the [Presto Server](https://github.com/prestosql/presto/tree/master/presto-server). You'll notice how small the Presto Server [`pom.xml`](https://github.com/prestosql/presto/blob/master/presto-server/pom.xml) is even though, at the time of this writing, there are 30+ plugins packaged in the Presto Server build as per the [Provisio descriptor](https://github.com/prestosql/presto/blob/master/presto-server/src/main/provisio/presto.xml). As you'll read below, you only need to specify what you need in the Provisio descriptor and Maven will figure out the rest, correctly, without having to pollute your `pom.xml` with duplicated dependendency declarations.
 
@@ -253,6 +254,21 @@ What follows are various techniques and capabilities for building runtimes. Prov
     </artifactSet>
   </artifactSet>
 </runtime>
+```
+
+<a name="feature10"></a>
+## Generating dependencies
+
+If you do need all the dependencies to be defined in `pom.xml`, for example to use other Maven plugins that process them, use the `generate` Mojo to avoid having to manage them manually:
+```
+mvn provisio:generateDependencies -DpomFile=pom-generated.xml
+```
+
+Without `-DpomFile=pom-generated.xml`, dependencies would be added to the existing `pom.xml`, but it won't preserve any comments.
+
+To only check if the `pom.xml` file is already up to date, run:
+```
+mvn provisio:verifyDependencies
 ```
 
 # References

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/MavenProvisioner.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/MavenProvisioner.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,6 +84,17 @@ public class MavenProvisioner {
     processResourceSets(context);
     processFileSets(context);
     processRuntimeActions(context);
+
+    return result;
+  }
+
+  public Set<ProvisioArtifact> resolveArtifacts(ProvisioningRequest request) throws Exception {
+    ProvisioningContext context = new ProvisioningContext(request, null);
+
+    Set<ProvisioArtifact> result = new HashSet<>();
+    for (ArtifactSet artifactSet : context.getRequest().getRuntimeModel().getArtifactSets()) {
+      result.addAll(resolveArtifactSet(context, artifactSet));
+    }
 
     return result;
   }

--- a/provisio-maven-plugin/pom.xml
+++ b/provisio-maven-plugin/pom.xml
@@ -114,6 +114,19 @@
     </dependency>
     <!-- Test -->
     <dependency>
+      <groupId>io.takari.maven.plugins</groupId>
+      <artifactId>takari-plugin-testing</artifactId>
+      <version>2.9.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.takari.maven.plugins</groupId>
+      <artifactId>takari-plugin-integration-testing</artifactId>
+      <version>2.9.1</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/BaseMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/BaseMojo.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (C) 2015-2020 Jason van Zyl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.vanzyl.maven.plugins.provisio;
+
+import ca.vanzyl.provisio.model.ArtifactSet;
+import ca.vanzyl.provisio.model.ProvisioArtifact;
+import ca.vanzyl.provisio.model.ProvisioningRequest;
+import ca.vanzyl.provisio.model.Runtime;
+import io.takari.incrementalbuild.Incremental;
+import io.takari.incrementalbuild.Incremental.Configuration;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.artifact.ArtifactType;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.artifact.DefaultArtifactType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class BaseMojo
+        extends AbstractMojo {
+
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+  @Inject
+  protected RepositorySystem repositorySystem;
+
+  @Inject
+  protected Provisio provisio;
+
+  @Inject
+  protected MavenProjectHelper projectHelper;
+
+  @Parameter(defaultValue = "${project}")
+  @Incremental(configuration = Configuration.ignore)
+  protected MavenProject project;
+
+  @Parameter(defaultValue = "${repositorySystemSession}")
+  protected RepositorySystemSession repositorySystemSession;
+
+  @Parameter(required = true, defaultValue = "${basedir}/src/main/provisio")
+  protected File descriptorDirectory;
+
+  @Parameter(defaultValue = "${session}")
+  protected MavenSession session;
+
+  protected ProvisioArtifact projectArtifact() {
+    ProvisioArtifact jarArtifact = null;
+    //
+    // We also need to definitively know what others types of runtime artifacts have been created. Right now there
+    // is no real protocol for knowing what something like, say, the JAR plugin did to drop off a file somewhere. We
+    // need to improve this but for now we'll look.
+    //
+    File jar = new File(project.getBuild().getDirectory(), project.getArtifactId() + "-" + project.getVersion() + ".jar");
+    if (jar.exists()) {
+      jarArtifact = new ProvisioArtifact(project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion());
+      jarArtifact.setFile(jar);
+    }
+    return jarArtifact;
+  }
+
+  //
+  // We want to produce an artifact set the corresponds to the runtime classpath of the project. This ArtifactSet will contain:
+  //
+  // - runtime dependencies
+  // - any artifacts produced by this build
+  //
+  protected ArtifactSet getRuntimeClasspathAsArtifactSet() {
+    //
+    // project.getArtifacts() will return us the runtime artifacts as that's the resolution scope we have requested
+    // for this Mojo. I think this will be sufficient for anything related to creating a runtime.
+    //
+    ArtifactSet artifactSet = new ArtifactSet();
+    for (org.apache.maven.artifact.Artifact mavenArtifact : project.getArtifacts()) {
+      if (!mavenArtifact.getScope().equals("system") && !mavenArtifact.getScope().equals("provided")) {
+        artifactSet.addArtifact(new ProvisioArtifact(toArtifact(mavenArtifact)));
+      }
+    }
+    return artifactSet;
+  }
+
+  private static Artifact toArtifact(org.apache.maven.artifact.Artifact artifact) {
+    if (artifact == null) {
+      return null;
+    }
+
+    String version = artifact.getVersion();
+    if (version == null && artifact.getVersionRange() != null) {
+      version = artifact.getVersionRange().toString();
+    }
+
+    Map<String, String> props = null;
+    if (org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(artifact.getScope())) {
+      String localPath = (artifact.getFile() != null) ? artifact.getFile().getPath() : "";
+      props = Collections.singletonMap(ArtifactProperties.LOCAL_PATH, localPath);
+    }
+
+    Artifact result = new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getClassifier(), artifact.getArtifactHandler().getExtension(), version, props,
+      newArtifactType(artifact.getType(), artifact.getArtifactHandler()));
+    result = result.setFile(artifact.getFile());
+
+    return result;
+  }
+
+  private static ArtifactType newArtifactType(String id, ArtifactHandler handler) {
+    return new DefaultArtifactType(id, handler.getExtension(), handler.getClassifier(), handler.getLanguage(), handler.isAddedToClasspath(), handler.isIncludesDependencies());
+  }
+
+  protected ProvisioningRequest getRequest(Runtime runtime)
+  {
+    ProvisioningRequest request = new ProvisioningRequest();
+    request.setRuntimeDescriptor(runtime);
+    request.setVariables(runtime.getVariables());
+    request.setManagedDependencies(provisio.getManagedDependencies(project));
+    return request;
+  }
+
+
+  public static Model readModel(File pomFile, Model defaultModel)
+          throws MojoExecutionException
+  {
+    Reader reader = null;
+    try {
+      reader = ReaderFactory.newXmlReader(pomFile);
+      final Model model = new MavenXpp3Reader().read(reader);
+      reader.close();
+      return model;
+    }
+    catch (FileNotFoundException e) {
+      return defaultModel;
+    }
+    catch (IOException e) {
+      throw new MojoExecutionException("Error reading POM " + pomFile, e);
+    }
+    catch (XmlPullParserException e) {
+      throw new MojoExecutionException("Error parsing POM " + pomFile, e);
+    }
+    finally {
+      IOUtil.close(reader);
+    }
+  }
+}

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/GeneratorMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/GeneratorMojo.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015-2020 Jason van Zyl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.vanzyl.maven.plugins.provisio;
+
+import ca.vanzyl.provisio.MavenProvisioner;
+import ca.vanzyl.provisio.model.ProvisioArtifact;
+import ca.vanzyl.provisio.model.ProvisioningRequest;
+import ca.vanzyl.provisio.model.Runtime;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.WriterFactory;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+
+@Mojo(name = "generateDependencies", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class GeneratorMojo
+        extends BaseMojo
+{
+    /**
+     * Location of an existing POM file in which dependencies should be updated.
+     */
+    @Parameter(required = true, property = "pomFile", defaultValue = "${basedir}/pom.xml")
+    private File pomFile;
+
+    public void execute()
+            throws MojoExecutionException, MojoFailureException
+    {
+        MavenProvisioner provisioner = new MavenProvisioner(repositorySystem, repositorySystemSession, project.getRemoteProjectRepositories());
+
+        Set<ProvisioArtifact> artifacts = new HashSet<>();
+        for (Runtime runtime : provisio.findDescriptors(descriptorDirectory, project)) {
+            runtime.addArtifactSetReference("runtime.classpath", getRuntimeClasspathAsArtifactSet());
+
+            ProvisioningRequest request = getRequest(runtime);
+            try {
+                artifacts.addAll(provisioner.resolveArtifacts(request));
+            }
+            catch (Exception e) {
+                throw new MojoExecutionException("Error resolving artifacts.", e);
+            }
+        }
+        Model model = readModel(pomFile, project.getModel().clone());
+        Set<Dependency> dependencies = getDependencies(artifacts);
+        mergeDependencies(model, dependencies);
+        writeModel(pomFile, model);
+    }
+
+    private Set<Dependency> getDependencies(Set<ProvisioArtifact> artifacts)
+    {
+        Set<Dependency> dependencies = new HashSet<>();
+        for (ProvisioArtifact artifact : artifacts) {
+            Dependency dependency = new Dependency();
+            dependency.setGroupId(artifact.getGroupId());
+            dependency.setArtifactId(artifact.getArtifactId());
+            dependency.setVersion(artifact.getVersion());
+            if (artifact.getClassifier() != null && artifact.getClassifier().length() != 0) {
+                dependency.setClassifier(artifact.getClassifier());
+            }
+            if (artifact.getExtension() != null && artifact.getExtension().length() != 0 && !artifact.getExtension().equals("jar")) {
+                dependency.setType(artifact.getExtension());
+            }
+            dependencies.add(dependency);
+        }
+        return dependencies;
+    }
+
+    private void mergeDependencies(Model model, Set<Dependency> dependencies)
+    {
+        for (Dependency dependency : model.getDependencies()) {
+            if (dependency.getScope() != null && !dependency.getScope().equals("compile")) {
+                dependencies.add(dependency);
+            }
+        }
+        ArrayList<Dependency> sorted = new ArrayList<>(dependencies);
+        sorted.sort(
+                Comparator.comparing(Dependency::getScope, Comparator.nullsFirst(Comparator.naturalOrder()))
+                        .thenComparing(Dependency::getGroupId)
+                        .thenComparing(Dependency::getArtifactId)
+                        .thenComparing(Dependency::getVersion)
+                        .thenComparing(Dependency::getClassifier, Comparator.nullsFirst(Comparator.naturalOrder()))
+                        .thenComparing(Dependency::getType, Comparator.nullsFirst(Comparator.naturalOrder())));
+        model.setDependencies(sorted);
+    }
+
+    private void writeModel(File pomFile, Model model)
+            throws MojoExecutionException
+    {
+        Writer writer = null;
+        try {
+            writer = WriterFactory.newXmlWriter(pomFile);
+            new MavenXpp3Writer().write(writer, model);
+            writer.close();
+        }
+        catch (IOException e) {
+            throw new MojoExecutionException("Error writing POM file: " + e.getMessage(), e);
+        }
+        finally {
+            IOUtil.close(writer);
+        }
+    }
+}

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningMojo.java
@@ -17,72 +17,29 @@ package ca.vanzyl.maven.plugins.provisio;
 
 import ca.vanzyl.provisio.model.ProvisioArchive;
 import java.io.File;
-import java.util.Collections;
-import java.util.Map;
-
-import javax.inject.Inject;
 
 import ca.vanzyl.provisio.model.ArtifactSet;
 import ca.vanzyl.provisio.model.ProvisioArtifact;
 import ca.vanzyl.provisio.model.ProvisioningRequest;
 import ca.vanzyl.provisio.model.ProvisioningResult;
 import ca.vanzyl.provisio.model.Runtime;
-import org.apache.maven.artifact.handler.ArtifactHandler;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectHelper;
-import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.ArtifactProperties;
-import org.eclipse.aether.artifact.ArtifactType;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.artifact.DefaultArtifactType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ca.vanzyl.provisio.MavenProvisioner;
-import io.takari.incrementalbuild.Incremental;
-import io.takari.incrementalbuild.Incremental.Configuration;
 
 @Mojo(name = "provision", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
-public class ProvisioningMojo extends AbstractMojo {
-
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
-
-  @Inject
-  private RepositorySystem repositorySystem;
-
-  @Inject
-  private Provisio provisio;
-
-  @Inject
-  private MavenProjectHelper projectHelper;
-
-  @Parameter(defaultValue = "${project}")
-  @Incremental(configuration = Configuration.ignore)
-  protected MavenProject project;
-
-  @Parameter(defaultValue = "${repositorySystemSession}")
-  private RepositorySystemSession repositorySystemSession;
+public class ProvisioningMojo extends BaseMojo {
 
   @Parameter(defaultValue = "${project.build.directory}/${project.artifactId}-${project.version}")
   private File outputDirectory;
 
-  @Parameter(required = true, defaultValue = "${basedir}/src/main/provisio")
-  private File descriptorDirectory;
-
-  @Parameter(defaultValue = "${session}")
-  private MavenSession session;
-
   public void execute() throws MojoExecutionException, MojoFailureException {
+    MavenProvisioner provisioner = new MavenProvisioner(repositorySystem, repositorySystemSession, project.getRemoteProjectRepositories());
 
     for (Runtime runtime : provisio.findDescriptors(descriptorDirectory, project)) {
       //
@@ -105,13 +62,9 @@ public class ProvisioningMojo extends AbstractMojo {
       //
       // Provision the runtime
       //
-      ProvisioningRequest request = new ProvisioningRequest();
+      ProvisioningRequest request = getRequest(runtime);
       request.setOutputDirectory(outputDirectory);
-      request.setRuntimeDescriptor(runtime);
-      request.setVariables(runtime.getVariables());
-      request.setManagedDependencies(provisio.getManagedDependencies(project));
 
-      MavenProvisioner provisioner = new MavenProvisioner(repositorySystem, repositorySystemSession, project.getRemoteProjectRepositories());
       ProvisioningResult result;
       try {
         result = provisioner.provision(request);
@@ -119,80 +72,16 @@ public class ProvisioningMojo extends AbstractMojo {
         throw new MojoExecutionException("Error provisioning assembly.", e);
       }
 
-      if (result.getArchives() != null) {
-        if (result.getArchives().size() == 1) {
-          ProvisioArchive provisioArchive = result.getArchives().get(0);
-          if(project.getPackaging().equals("jar") || project.getPackaging().equals("takari-jar")) {
-            projectHelper.attachArtifact(project, provisioArchive.extension(), provisioArchive.file());
-          } else {
-            // We have something like provisio or presto-plugin
-            project.getArtifact().setFile(provisioArchive.file());
-          }
-        }
+      if (result.getArchives() == null || result.getArchives().size() != 1) {
+        continue;
       }
-    }
-  }
-
-  private ProvisioArtifact projectArtifact() {
-    ProvisioArtifact jarArtifact = null;
-    //
-    // We also need to definitively know what others types of runtime artifacts have been created. Right now there
-    // is no real protocol for knowing what something like, say, the JAR plugin did to drop off a file somewhere. We
-    // need to improve this but for now we'll look.
-    //
-    File jar = new File(project.getBuild().getDirectory(), project.getArtifactId() + "-" + project.getVersion() + ".jar");
-    if (jar.exists()) {
-      jarArtifact = new ProvisioArtifact(project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion());
-      jarArtifact.setFile(jar);
-    }
-    return jarArtifact;
-  }
-
-  //
-  // We want to produce an artifact set the corresponds to the runtime classpath of the project. This ArtifactSet will contain:
-  //
-  // - runtime dependencies
-  // - any artifacts produced by this build
-  //
-  private ArtifactSet getRuntimeClasspathAsArtifactSet() {
-    //
-    // project.getArtifacts() will return us the runtime artifacts as that's the resolution scope we have requested
-    // for this Mojo. I think this will be sufficient for anything related to creating a runtime.
-    //
-    ArtifactSet artifactSet = new ArtifactSet();
-    for (org.apache.maven.artifact.Artifact mavenArtifact : project.getArtifacts()) {
-      if (!mavenArtifact.getScope().equals("system") && !mavenArtifact.getScope().equals("provided")) {
-        artifactSet.addArtifact(new ProvisioArtifact(toArtifact(mavenArtifact)));
+      ProvisioArchive provisioArchive = result.getArchives().get(0);
+      if (project.getPackaging().equals("jar") || project.getPackaging().equals("takari-jar")) {
+        projectHelper.attachArtifact(project, provisioArchive.extension(), provisioArchive.file());
+        continue;
       }
+      // We have something like provisio or presto-plugin
+      project.getArtifact().setFile(provisioArchive.file());
     }
-    return artifactSet;
   }
-
-  private static Artifact toArtifact(org.apache.maven.artifact.Artifact artifact) {
-    if (artifact == null) {
-      return null;
-    }
-
-    String version = artifact.getVersion();
-    if (version == null && artifact.getVersionRange() != null) {
-      version = artifact.getVersionRange().toString();
-    }
-
-    Map<String, String> props = null;
-    if (org.apache.maven.artifact.Artifact.SCOPE_SYSTEM.equals(artifact.getScope())) {
-      String localPath = (artifact.getFile() != null) ? artifact.getFile().getPath() : "";
-      props = Collections.singletonMap(ArtifactProperties.LOCAL_PATH, localPath);
-    }
-
-    Artifact result = new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getClassifier(), artifact.getArtifactHandler().getExtension(), version, props,
-      newArtifactType(artifact.getType(), artifact.getArtifactHandler()));
-    result = result.setFile(artifact.getFile());
-
-    return result;
-  }
-
-  private static ArtifactType newArtifactType(String id, ArtifactHandler handler) {
-    return new DefaultArtifactType(id, handler.getExtension(), handler.getClassifier(), handler.getLanguage(), handler.isAddedToClasspath(), handler.isIncludesDependencies());
-  }
-
 }

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2015-2020 Jason van Zyl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.vanzyl.maven.plugins.provisio;
+
+import ca.vanzyl.provisio.MavenProvisioner;
+import ca.vanzyl.provisio.model.ProvisioArtifact;
+import ca.vanzyl.provisio.model.ProvisioningRequest;
+import ca.vanzyl.provisio.model.Runtime;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Mojo(name = "validateDependencies", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class ValidatorMojo
+        extends BaseMojo
+{
+    /**
+     * Location of an existing POM file in which dependencies should be validated.
+     */
+    @Parameter(required = true, property = "pomFile", defaultValue = "${basedir}/pom.xml")
+    private File pomFile;
+
+    public void execute()
+            throws MojoExecutionException, MojoFailureException
+    {
+        MavenProvisioner provisioner = new MavenProvisioner(repositorySystem, repositorySystemSession, project.getRemoteProjectRepositories());
+
+        Set<ProvisioArtifact> artifacts = new HashSet<>();
+        for (Runtime runtime : provisio.findDescriptors(descriptorDirectory, project)) {
+            runtime.addArtifactSetReference("runtime.classpath", getRuntimeClasspathAsArtifactSet());
+
+            ProvisioningRequest request = getRequest(runtime);
+            try {
+                artifacts.addAll(provisioner.resolveArtifacts(request));
+            }
+            catch (Exception e) {
+                throw new MojoExecutionException("Error resolving artifacts.", e);
+            }
+        }
+        Model model = readModel(pomFile, project.getModel().clone());
+        Set<String> dependencies = flattenDependencies(getDependencies(artifacts));
+        Set<String> modelDependencies = flattenDependencies(model.getDependencies()
+                .stream()
+                .filter(d -> d.getScope() == null || d.getScope().equals("compile"))
+                .collect(Collectors.toSet()));
+
+        checkDependencies(modelDependencies, dependencies);
+    }
+
+    private Set<Dependency> getDependencies(Set<ProvisioArtifact> artifacts)
+    {
+        Set<Dependency> dependencies = new HashSet<>();
+        for (ProvisioArtifact artifact : artifacts) {
+            Dependency dependency = new Dependency();
+            dependency.setGroupId(artifact.getGroupId());
+            dependency.setArtifactId(artifact.getArtifactId());
+            dependency.setVersion(artifact.getVersion());
+            if (artifact.getClassifier() != null && artifact.getClassifier().length() != 0) {
+                dependency.setClassifier(artifact.getClassifier());
+            }
+            if (artifact.getExtension() != null && artifact.getExtension().length() != 0 && !artifact.getExtension().equals("jar")) {
+                dependency.setType(artifact.getExtension());
+            }
+            dependencies.add(dependency);
+        }
+        return dependencies;
+    }
+
+    private Set<String> flattenDependencies(Set<Dependency> dependencies)
+    {
+        return dependencies
+                .stream()
+                .map(d -> d.getGroupId() +
+                        ":" + d.getArtifactId() +
+                        prefixed(d.getType(), ":jar") +
+                        prefixed(d.getClassifier()) +
+                        ":" + d.getVersion())
+                .collect(Collectors.toSet());
+    }
+
+    private String prefixed(String value)
+    {
+        return prefixed(value, "");
+    }
+
+    private String prefixed(String value, String defaultValue)
+    {
+        if (value == null) {
+            return defaultValue;
+        }
+        return ":" + value;
+    }
+
+    /**
+     * Throws an exception if there are no extra or missing dependencies in the model.
+     */
+    private void checkDependencies(Set<String> actual, Set<String> expected)
+            throws MojoFailureException
+    {
+        HashSet<String> missing = new HashSet<>(expected);
+        missing.removeAll(actual);
+
+        actual.removeAll(expected);
+
+        if (!missing.isEmpty()) {
+            throw new MojoFailureException("Missing dependencies: " + String.join(", ", missing));
+        }
+
+        if (!actual.isEmpty()) {
+            throw new MojoFailureException("Extra dependencies: " + String.join(", ", actual));
+        }
+    }
+}

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
@@ -55,6 +55,17 @@ public class GeneratorIntegrationTest
         testGenerator("basic");
     }
 
+    @Test
+    public void testConflict()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("conflict");
+        maven.forProject(basedir)
+                .withCliOption("-DpomFile=generated.xml")
+                .execute("provisio:generateDependencies")
+                .assertLogText("[ERROR] Failed to execute goal ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin:1.0.16-SNAPSHOT:generateDependencies (default-cli) on project conflict: Found different versions of the same dependency: junit:junit:jar:4.13.2, junit:junit:jar:4.13.1 -> [Help 1]");
+    }
+
     protected void testGenerator(String projectId)
             throws Exception
     {

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2015-2020 Jason van Zyl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.vanzyl.maven.plugins.provisio;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertArrayEquals;
+
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.3.9", "3.5.4", "3.6.3", "3.8.1"})
+@SuppressWarnings({"JUnitTestNG", "PublicField"})
+public class GeneratorIntegrationTest
+{
+    @Rule
+    public final TestResources resources = new TestResources();
+
+    public final MavenRuntime maven;
+
+    public GeneratorIntegrationTest(MavenRuntimeBuilder mavenBuilder)
+            throws Exception
+    {
+        this.maven = mavenBuilder.withCliOptions("-B", "-U").build();
+    }
+
+    @Test
+    public void testBasic()
+            throws Exception
+    {
+        testGenerator("basic");
+    }
+
+    protected void testGenerator(String projectId)
+            throws Exception
+    {
+        File basedir = resources.getBasedir(projectId);
+        maven.forProject(basedir)
+                .withCliOption("-DpomFile=generated.xml")
+                .execute("provisio:generateDependencies")
+                .assertErrorFreeLog();
+
+        Model model = BaseMojo.readModel(new File(basedir, "generated.xml"), null);
+        List<String> dependencies = flattenDependencies(model.getDependencies());
+
+        String[] expected = {
+                "junit:junit:jar:4.13.2:runtime",
+                "org.hamcrest:hamcrest-core:jar:1.3:runtime",
+                "io.trino:trino-spi:jar:356:provided"};
+        assertArrayEquals(expected, dependencies.toArray());
+    }
+
+    private List<String> flattenDependencies(List<Dependency> dependencies)
+    {
+        return dependencies
+                .stream()
+                .map(d -> d.getGroupId() +
+                        ":" + d.getArtifactId() +
+                        prefixed(d.getType(), ":jar") +
+                        prefixed(d.getClassifier(), "") +
+                        ":" + d.getVersion() +
+                        prefixed(d.getScope(), ":runtime"))
+                .collect(Collectors.toList());
+    }
+
+    private String prefixed(String value, String defaultValue)
+    {
+        if (value == null) {
+            return defaultValue;
+        }
+        return ":" + value;
+    }
+}

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ValidatorIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ValidatorIntegrationTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2015-2020 Jason van Zyl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.vanzyl.maven.plugins.provisio;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.3.9", "3.5.4", "3.6.3", "3.8.1"})
+@SuppressWarnings({"JUnitTestNG", "PublicField"})
+public class ValidatorIntegrationTest
+{
+    @Rule
+    public final TestResources resources = new TestResources();
+
+    public final MavenRuntime maven;
+
+    public ValidatorIntegrationTest(MavenRuntimeBuilder mavenBuilder)
+            throws Exception
+    {
+        this.maven = mavenBuilder.withCliOptions("-B", "-U").build();
+    }
+
+    @Test
+    public void testIncomplete()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("basic");
+
+        maven.forProject(basedir)
+                .execute("provisio:validateDependencies")
+                .assertLogText("[ERROR] Failed to execute goal ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin:1.0.16-SNAPSHOT:validateDependencies (default-cli) on project basic: Missing dependencies: junit:junit:jar:4.13.2, org.hamcrest:hamcrest-core:jar:1.3 -> [Help 1]");
+    }
+
+    @Test
+    public void testComplete()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("complete");
+        maven.forProject(basedir)
+                .execute("provisio:validateDependencies")
+                .assertErrorFreeLog();
+    }
+}

--- a/provisio-maven-plugin/src/test/projects/basic/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/basic/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
+    <artifactId>basic</artifactId>
+    <version>1.0</version>
+    <packaging>trino-plugin</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <version>356</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-maven-plugin</artifactId>
+                <version>10</version>
+                <extensions>true</extensions>
+            </plugin>
+
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>1.0.16-SNAPSHOT</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/provisio-maven-plugin/src/test/projects/basic/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/basic/src/main/provisio/provisio.xml
@@ -1,0 +1,7 @@
+<assembly>
+
+  <artifactSet to="lib">
+    <artifact id="junit:junit:4.13.2"/>
+  </artifactSet>
+
+</assembly>

--- a/provisio-maven-plugin/src/test/projects/complete/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/complete/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
+    <artifactId>basic</artifactId>
+    <version>1.0</version>
+    <packaging>trino-plugin</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <version>356</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-maven-plugin</artifactId>
+                <version>10</version>
+                <extensions>true</extensions>
+            </plugin>
+
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>1.0.16-SNAPSHOT</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/provisio-maven-plugin/src/test/projects/complete/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/complete/src/main/provisio/provisio.xml
@@ -1,0 +1,7 @@
+<assembly>
+
+  <artifactSet to="lib">
+    <artifact id="junit:junit:4.13.2"/>
+  </artifactSet>
+
+</assembly>

--- a/provisio-maven-plugin/src/test/projects/conflict/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/conflict/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
-    <artifactId>complete</artifactId>
+    <artifactId>conflict</artifactId>
     <version>1.0</version>
     <packaging>trino-plugin</packaging>
 
@@ -12,16 +12,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
-        </dependency>
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>

--- a/provisio-maven-plugin/src/test/projects/conflict/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/conflict/src/main/provisio/provisio.xml
@@ -1,0 +1,11 @@
+<assembly>
+
+  <artifactSet to="lib">
+    <artifact id="junit:junit:4.13.2"/>
+  </artifactSet>
+
+  <artifactSet to="lib2">
+    <artifact id="junit:junit:4.13.1"/>
+  </artifactSet>
+
+</assembly>


### PR DESCRIPTION
Add two Mojos to generate a (new) `pom.xml` with dependencies and to verify that an existing `pom.xml` has all the correct dependencies (and no extra ones). Should resolve #13.

This could be used with other Maven plugins that require an up-to-date dependency list, for example [License Maven Plugin](https://www.mojohaus.org/license-maven-plugin/).

Because `pom.xml` can contain comments, and the default serializer I used would remove them, a semi-manual workflow could be used:
* call `mvn provisio:generateDependencies -DpomFile=generated.xml`
* manually compare `generated.xml` with `pom.xml` and copy the dependencies
* add `mvn provisio:validateDependencies` to the CI to detect when the Provisio descriptor is modified but `pom.xml` is not updated

Otherwise, the generator mojo can be called even in a pre-commit git hook.

I desperately need help with writing tests. I tried, but failed miserably, with:
1. Running the `MavenInvokerTest` complains about `maven` param not being injected. I have no idea how to provide this value.
2. Tests in `provisio-its` doesn't look like they should/could test Mojos.
3. I tried adding unit tests using `Maven Plugin Testing Harness` but failed to figure out how to pass custom params (`pomFile`).
4. I tried adding [Maven Invoker Plugin](https://maven.apache.org/plugins/maven-invoker-plugin/index.html) but it had issues with executing Mojos and mixing a different kind of ITs doesn't seem like a good idea anyway.

Some disclosures:
1.  I work at Starburst Data
2. I don't know Java very well, and Maven even less so. But I did read the [POM reference](https://maven.apache.org/pom.html).