### PR TITLE
Add dependencies to published pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ What follows are various techniques and capabilities for building runtimes. Prov
 
 If you do need all the dependencies to be defined in `pom.xml`, for example to use other Maven plugins that process them, use the `generate` Mojo to avoid having to manage them manually:
 ```
-mvn provisio:generateDependencies -DpomFile=pom-generated.xml
+mvn provisio:generateDependencies -DdependencyExtendedPomLocation=pom-generated.xml
 ```
 
 Without `-DpomFile=pom-generated.xml`, dependencies would be added to the existing `pom.xml`, but it won't preserve any comments.

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
@@ -9,6 +9,7 @@ import ca.vanzyl.provisio.maven.MavenInstallationProvisioner;
 import ca.vanzyl.provisio.maven.MavenInvoker;
 import ca.vanzyl.provisio.maven.MavenRequest;
 import ca.vanzyl.provisio.maven.MavenResult;
+import ca.vanzyl.provisio.model.ProvisioArtifact;
 import ca.vanzyl.provisio.model.ProvisioningRequest;
 import ca.vanzyl.provisio.model.ProvisioningResult;
 import ca.vanzyl.provisio.model.Runtime;
@@ -25,6 +26,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/GeneratorMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/GeneratorMojo.java
@@ -58,7 +58,7 @@ public class GeneratorMojo
 
             ProvisioningRequest request = getRequest(runtime);
             try {
-                artifacts.addAll(provisioner.resolveArtifacts(request));
+                artifacts.addAll(provisioner.getArtifacts(request));
             }
             catch (Exception e) {
                 throw new MojoExecutionException("Error resolving artifacts.", e);

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningMojo.java
@@ -38,7 +38,7 @@ public class ProvisioningMojo extends BaseMojo {
   @Parameter(defaultValue = "${project.build.directory}/${project.artifactId}-${project.version}")
   private File outputDirectory;
 
-  public void execute() throws MojoExecutionException, MojoFailureException {
+  public void execute() throws MojoExecutionException {
     MavenProvisioner provisioner = new MavenProvisioner(repositorySystem, repositorySystemSession, project.getRemoteProjectRepositories());
 
     for (Runtime runtime : provisio.findDescriptors(descriptorDirectory, project)) {

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
@@ -55,7 +55,7 @@ public class ValidatorMojo
 
             ProvisioningRequest request = getRequest(runtime);
             try {
-                artifacts.addAll(provisioner.resolveArtifacts(request));
+                artifacts.addAll(provisioner.getArtifacts(request));
             }
             catch (Exception e) {
                 throw new MojoExecutionException("Error resolving artifacts.", e);

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
@@ -62,7 +62,7 @@ public class ValidatorMojo
             }
         }
         checkDuplicates(artifacts);
-        Model model = readModel(pomFile, project.getModel().clone());
+        Model model = project.getModel().clone();
         Set<String> dependencies = flattenDependencies(getDependencies(artifacts));
         Set<String> modelDependencies = flattenDependencies(model.getDependencies()
                 .stream()

--- a/provisio-maven-plugin/src/main/resources-filtered/META-INF/plexus/components.xml
+++ b/provisio-maven-plugin/src/main/resources-filtered/META-INF/plexus/components.xml
@@ -38,6 +38,9 @@
           <lifecycle>
             <id>default</id>
             <phases>
+              <generate-resources>
+                ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin:${project.version}:generateDependencies
+              </generate-resources>
               <process-resources>
                 io.takari.maven.plugins:takari-lifecycle-plugin:${takariLifecyclePluginVersion}:process-resources
               </process-resources>
@@ -89,6 +92,9 @@
           <lifecycle>
             <id>default</id>
             <phases>
+              <generate-resources>
+                ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin:${project.version}:generateDependencies
+              </generate-resources>
               <process-resources>
                 io.takari.maven.plugins:takari-lifecycle-plugin:${takariLifecyclePluginVersion}:process-resources
               </process-resources>

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
@@ -82,7 +82,6 @@ public class GeneratorIntegrationTest
 
         String[] expected = {
                 "junit:junit:jar:4.13.2:runtime",
-                "org.hamcrest:hamcrest-core:jar:1.3:runtime",
                 "io.trino:trino-spi:jar:356:provided"};
         assertArrayEquals(expected, dependencies.toArray());
     }

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ValidatorIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ValidatorIntegrationTest.java
@@ -51,8 +51,7 @@ public class ValidatorIntegrationTest
         maven.forProject(basedir)
                 .execute("provisio:validateDependencies")
                 .assertLogText("[ERROR] Failed to execute goal ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin:")
-                .assertLogText("validateDependencies (default-cli) on project basic: Missing dependencies: junit:junit:jar:4.13.2, org.hamcrest:hamcrest-core:jar:1.3 -> [Help 1]");
-
+                .assertLogText("validateDependencies (default-cli) on project basic: Missing dependencies: junit:junit:jar:4.13.2 -> [Help 1]");
     }
 
     @Test

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ValidatorIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ValidatorIntegrationTest.java
@@ -51,7 +51,7 @@ public class ValidatorIntegrationTest
         maven.forProject(basedir)
                 .execute("provisio:validateDependencies")
                 .assertLogText("[ERROR] Failed to execute goal ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin:")
-                .assertLogText("validateDependencies (default-cli) on project basic: Missing dependencies: junit:junit:jar:4.13.2 -> [Help 1]");
+                .assertLogText("validateDependencies (default-cli) on project basic: Missing dependencies: org.scala-lang:scala-library:jar:2.13.6 -> [Help 1]");
     }
 
     @Test

--- a/provisio-maven-plugin/src/test/projects/basic/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/basic/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ca.vanzyl</groupId>
         <artifactId>provisio</artifactId>
-        <version>1.0.17-SNAPSHOT</version>
+        <version>1.0.18-SNAPSHOT</version>
     </parent>
     <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
     <artifactId>basic</artifactId>
@@ -36,6 +36,7 @@
             <plugin>
                 <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
                 <artifactId>provisio-maven-plugin</artifactId>
+                <version>1.0.18-SNAPSHOT</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/provisio-maven-plugin/src/test/projects/basic/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/basic/src/main/provisio/provisio.xml
@@ -1,7 +1,7 @@
 <assembly>
 
   <artifactSet to="lib">
-    <artifact id="junit:junit:4.13.2"/>
+    <artifact id="org.scala-lang:scala-library:2.13.6"/>
   </artifactSet>
 
 </assembly>

--- a/provisio-maven-plugin/src/test/projects/complete/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/complete/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ca.vanzyl</groupId>
         <artifactId>provisio</artifactId>
-        <version>1.0.17-SNAPSHOT</version>
+        <version>1.0.18-SNAPSHOT</version>
     </parent>
     <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
     <artifactId>complete</artifactId>
@@ -17,14 +17,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.13.6</version>
         </dependency>
         <dependency>
             <groupId>io.trino</groupId>
@@ -46,6 +41,7 @@
             <plugin>
                 <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
                 <artifactId>provisio-maven-plugin</artifactId>
+                <version>1.0.18-SNAPSHOT</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/provisio-maven-plugin/src/test/projects/complete/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/complete/src/main/provisio/provisio.xml
@@ -1,7 +1,7 @@
 <assembly>
 
   <artifactSet to="lib">
-    <artifact id="junit:junit:4.13.2"/>
+    <artifact id="org.scala-lang:scala-library:2.13.6"/>
   </artifactSet>
 
 </assembly>

--- a/provisio-maven-plugin/src/test/projects/conflict/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/conflict/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ca.vanzyl</groupId>
         <artifactId>provisio</artifactId>
-        <version>1.0.17-SNAPSHOT</version>
+        <version>1.0.18-SNAPSHOT</version>
     </parent>
     <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
     <artifactId>conflict</artifactId>
@@ -36,6 +36,7 @@
             <plugin>
                 <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
                 <artifactId>provisio-maven-plugin</artifactId>
+                <version>1.0.18-SNAPSHOT</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/provisio-maven-plugin/src/test/projects/conflict/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/conflict/src/main/provisio/provisio.xml
@@ -1,11 +1,11 @@
 <assembly>
 
   <artifactSet to="lib">
-    <artifact id="junit:junit:4.13.2"/>
+    <artifact id="org.scala-lang:scala-library:2.13.6"/>
   </artifactSet>
 
   <artifactSet to="lib2">
-    <artifact id="junit:junit:4.13.1"/>
+    <artifact id="org.scala-lang:scala-library:2.13.5"/>
   </artifactSet>
 
 </assembly>


### PR DESCRIPTION
Add direct dependencies to the pom that will be instaled/published. There are two new parameters for the default mojo that allow to disable this behavior and change the path of the generated pom file.

I based this on how the shade maven plugin regenerates the pom.

The `generateDependencies` and `validateDependencies` mojos added in #40 (merged as #42) included transitive dependencies. But they should only add direct dependencies. This PR addresses this issue.