### PR TITLE
Make proviso build with Java11

### DIFF
--- a/provisio-maven/src/test/projects/maven/pom.xml
+++ b/provisio-maven/src/test/projects/maven/pom.xml
@@ -6,5 +6,7 @@
   <version>0.0.1-SNAPSHOT</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 </project>


### PR DESCRIPTION
Reason was that test project used defaults of old
maven, and java11 does NOT support java 5 target
anymore (that is default target).