### PR TITLE
Update plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,11 @@
-name: ci
+name: Verify
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stop old builds
-        if: github.ref != 'refs/heads/master'
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
   build:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-      - name: Set up JDK
-        uses: actions/setup-java@v2.3.1
-        with:
-          distribution: 'temurin'
-          java-version: 11
-          cache: maven
-      - name: Build & Test
-        run: ./mvnw -B install
+    name: Verify
+    uses: takari/takari-gh-actions/.github/workflows/ci.yml@v1
+

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>47</version>
+    <version>50</version>
   </parent>
 
   <groupId>ca.vanzyl</groupId>
@@ -44,9 +44,9 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <surefire.runOrder>alphabetical</surefire.runOrder>
     <surefire.mem>-Xmx256m</surefire.mem>
-    <mavenVersion>3.3.3</mavenVersion>
+    <mavenVersion>3.6.3</mavenVersion>
     <takariArchiverVersion>0.1.26</takariArchiverVersion>
-    <aetherVersion>1.0.2.v20150114</aetherVersion> <!-- Align with Aether version used in $mavenVersion -->
+    <aetherVersion>1.4.1</aetherVersion> <!-- Align with Aether version used in $mavenVersion -->
     <sisuVersion>0.3.5</sisuVersion>
     <takari.licenseHeader>license-header.txt</takari.licenseHeader>
   </properties>
@@ -101,6 +101,11 @@
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
         <version>1.4.18</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId> <!-- Is gone from Maven -->
+        <artifactId>guava</artifactId>
+        <version>31.0.1-jre</version>
       </dependency>
       <!-- Mustache -->
       <dependency>

--- a/provisio-core/pom.xml
+++ b/provisio-core/pom.xml
@@ -47,20 +47,20 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -94,8 +94,8 @@
     </dependency>
     <!-- Test -->
     <dependency>
-      <groupId>org.eclipse.aether</groupId> <!-- Align with used maven, GAV changes between 3.3.x-3.5.x! -->
-      <artifactId>aether-transport-file</artifactId>
+      <groupId>org.apache.maven.resolver</groupId> <!-- Align with used maven -->
+      <artifactId>maven-resolver-transport-file</artifactId>
       <version>${aetherVersion}</version>
       <scope>test</scope>
     </dependency>
@@ -107,7 +107,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/provisio-its/pom.xml
+++ b/provisio-its/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -77,20 +77,20 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -113,8 +113,8 @@
     <!-- We should add this to Maven so that I can use the import scoped
       POM above -->
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-file</artifactId>
+      <groupId>org.apache.maven.resolver</groupId> <!-- Align with used maven -->
+      <artifactId>maven-resolver-transport-file</artifactId>
       <version>${aetherVersion}</version>
     </dependency>
     <!-- Aether OkHttp Connector -->
@@ -132,4 +132,16 @@
       <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.takari.maven.plugins</groupId>
+        <artifactId>takari-lifecycle-plugin</artifactId>
+        <configuration>
+          <privatePackageReference>ignore</privatePackageReference>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/provisio-maven-plugin/pom.xml
+++ b/provisio-maven-plugin/pom.xml
@@ -98,31 +98,31 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-spi</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
       <scope>provided</scope>
     </dependency>
     <!-- Test -->
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>
       <artifactId>takari-plugin-testing</artifactId>
-      <version>2.9.1</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>
       <artifactId>takari-plugin-integration-testing</artifactId>
-      <version>2.9.1</version>
+      <version>3.0.1</version>
       <type>pom</type>
       <scope>test</scope>
     </dependency>

--- a/provisio-maven/pom.xml
+++ b/provisio-maven/pom.xml
@@ -51,8 +51,8 @@
       <version>${sisuVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
       <classifier>no_aop</classifier>
     </dependency>
     <dependency>

--- a/provisio-model/pom.xml
+++ b/provisio-model/pom.xml
@@ -35,12 +35,12 @@
       <version>1</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>


### PR DESCRIPTION
Changes:
* use shared takari GH Actions (builds with Java 11 and Java 17)
* use parent pom 50
* up maven version to 3.6.3 (and aether in lockstep as well)
* update takari plugin testing to latest released 3.0.1
* ITs: add privatePackageReference ignore as OSGi headers changed between 1.0.0 aether and 1.4.1 (latter enlists internal packages explicitly as private), but this is OK as this is test code