### PR TITLE
Update plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>50</version>
+    <version>51</version>
   </parent>
 
   <groupId>ca.vanzyl</groupId>
@@ -44,10 +44,10 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <surefire.runOrder>alphabetical</surefire.runOrder>
     <surefire.mem>-Xmx256m</surefire.mem>
-    <mavenVersion>3.6.3</mavenVersion>
-    <takariArchiverVersion>0.1.26</takariArchiverVersion>
-    <aetherVersion>1.4.1</aetherVersion> <!-- Align with Aether version used in $mavenVersion -->
-    <sisuVersion>0.3.5</sisuVersion>
+    <mavenVersion>3.9.6</mavenVersion>
+    <takariArchiverVersion>0.1.29</takariArchiverVersion>
+    <aetherVersion>1.9.18</aetherVersion> <!-- Align with Aether version used in $mavenVersion -->
+    <sisuVersion>0.9.0.M2</sisuVersion> <!-- Align with Sisu version used in $mavenVersion -->
     <takari.licenseHeader>license-header.txt</takari.licenseHeader>
   </properties>
 
@@ -100,18 +100,13 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.18</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId> <!-- Is gone from Maven -->
-        <artifactId>guava</artifactId>
-        <version>31.0.1-jre</version>
+        <version>1.4.20</version>
       </dependency>
       <!-- Mustache -->
       <dependency>
         <groupId>com.github.spullara.mustache.java</groupId>
         <artifactId>compiler</artifactId>
-        <version>0.9.2</version>
+        <version>0.9.11</version>
       </dependency>
       <!-- Testing -->
       <dependency>

--- a/provisio-core/pom.xml
+++ b/provisio-core/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp</artifactId>
-      <version>2.0.0</version>
+      <version>2.7.5</version>
     </dependency>
     <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/SimpleProvisioner.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/SimpleProvisioner.java
@@ -15,7 +15,7 @@
  */
 package ca.vanzyl.provisio;
 
-import io.tesla.proviso.archive.UnArchiver;
+import ca.vanzyl.provisio.archive.UnArchiver;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/UnpackAction.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/UnpackAction.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 import javax.inject.Named;
 
-import io.tesla.proviso.archive.UnArchiver;
+import ca.vanzyl.provisio.archive.UnArchiver;
 
 /**
  * The unpack is an operation that results in any number of artifacts and resources being contributed to the runtime. The archive to be unpacked can

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/alter/AlterAction.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/alter/AlterAction.java
@@ -36,8 +36,8 @@ import org.codehaus.plexus.util.FileUtils;
 
 import ca.vanzyl.provisio.MavenProvisioner;
 import ca.vanzyl.provisio.perms.PosixModes;
-import io.tesla.proviso.archive.Archiver;
-import io.tesla.proviso.archive.UnArchiver;
+import ca.vanzyl.provisio.archive.Archiver;
+import ca.vanzyl.provisio.archive.UnArchiver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/filter/MustacheFilteringProcessor.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/filter/MustacheFilteringProcessor.java
@@ -27,7 +27,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.Map;
 
-import io.tesla.proviso.archive.UnarchivingEntryProcessor;
+import ca.vanzyl.provisio.archive.UnarchivingEntryProcessor;
 
 public class MustacheFilteringProcessor implements UnarchivingEntryProcessor {
 

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/filter/StandardFilteringProcessor.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/filter/StandardFilteringProcessor.java
@@ -22,8 +22,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
 
-import io.tesla.proviso.archive.Selector;
-import io.tesla.proviso.archive.UnarchivingEntryProcessor;
+import ca.vanzyl.provisio.archive.Selector;
+import ca.vanzyl.provisio.archive.UnarchivingEntryProcessor;
 
 import static ca.vanzyl.provisio.ProvisioUtils.copy;
 

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/runtime/ArchiveAction.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/runtime/ArchiveAction.java
@@ -33,9 +33,9 @@ package ca.vanzyl.provisio.action.runtime;
 import ca.vanzyl.provisio.model.ProvisioArchive;
 import ca.vanzyl.provisio.model.ProvisioningAction;
 import ca.vanzyl.provisio.model.ProvisioningContext;
-import io.tesla.proviso.archive.Archiver;
-import io.tesla.proviso.archive.Archiver.ArchiverBuilder;
-import io.tesla.proviso.archive.UnArchiver;
+import ca.vanzyl.provisio.archive.Archiver;
+import ca.vanzyl.provisio.archive.Archiver.ArchiverBuilder;
+import ca.vanzyl.provisio.archive.UnArchiver;
 import java.io.File;
 import org.codehaus.plexus.util.StringUtils;
 

--- a/provisio-its/pom.xml
+++ b/provisio-its/pom.xml
@@ -93,8 +93,17 @@
       <artifactId>maven-resolver-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-file</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-supplier</artifactId>
+      <version>1.9.18</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -105,23 +114,9 @@
       <artifactId>takari-archiver</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.takari</groupId>
-      <artifactId>takari-archiver</artifactId>
-      <version>${takariArchiverVersion}</version>
-      <classifier>tests</classifier>
-    </dependency>
-    <!-- We should add this to Maven so that I can use the import scoped
-      POM above -->
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId> <!-- Align with used maven -->
-      <artifactId>maven-resolver-transport-file</artifactId>
-      <version>${aetherVersion}</version>
-    </dependency>
-    <!-- Aether OkHttp Connector -->
-    <dependency>
-      <groupId>io.takari.aether</groupId>
-      <artifactId>aether-connector-okhttp</artifactId>
-      <version>${okhttpConnectorVersion}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/archive/AbstractArchiveValidator.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/archive/AbstractArchiveValidator.java
@@ -1,0 +1,129 @@
+package ca.vanzyl.provisio.archive;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+public abstract class AbstractArchiveValidator implements ArchiveValidator {
+
+  protected final MultiMap<String, TestEntry> entries;
+
+  protected AbstractArchiveValidator(Source source) throws IOException {
+    MultiMap<String, TestEntry> entries = new MultiMap<>();
+    for (ExtendedArchiveEntry entry : source.entries()) {
+      OutputStream outputStream = new ByteArrayOutputStream();
+      entry.getInputStream().transferTo(outputStream);
+      entries.put(entry.getName(), new TestEntry(entry.getName(), outputStream.toString(), entry.getTime(), entry.getSize()));
+    }
+    this.entries = entries;
+  }
+
+  @Override
+  public void assertEntries(String... expectedEntries) throws IOException {
+    String expected = toString(Arrays.asList(expectedEntries));
+    List<String> actual = new ArrayList<>();
+    for (Entry<String, List<TestEntry>> entry : entries.entries()) {
+      actual.add(entry.getKey());
+    }
+    assertEquals("Archive entries", expected, toString(actual));
+  }
+
+  @Override
+  public void assertEntryExists(String expectedEntry) {
+    assertTrue("Expected to find " + expectedEntry, entries.containsKey(expectedEntry));
+  }
+
+  @Override
+  public void assertEntryDoesntExist(String missingEntry) {
+    assertFalse("Expected not to find " + missingEntry, entries.containsKey(missingEntry));
+  }
+
+  private String toString(Collection<String> strings) {
+    List<String> sorted = new ArrayList<>(strings);
+    Collections.sort(sorted);
+    StringBuilder sb = new StringBuilder();
+    for (String string : sorted) {
+      sb.append(string).append('\n');
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public void assertSortedEntries(String... expectedEntries) {
+    String expected = toString(Arrays.asList(expectedEntries));
+    List<String> actual = new ArrayList<>();
+    for (Entry<String, List<TestEntry>> entry : entries.entries()) {
+      actual.add(entry.getKey());
+    }
+    assertEquals("Archive entries", expected, toNonSortedString(actual));
+  }
+
+  private String toNonSortedString(Collection<String> strings) {
+    List<String> sorted = new ArrayList<>(strings);
+    StringBuilder sb = new StringBuilder();
+    for (String string : sorted) {
+      sb.append(string).append('\n');
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public void assertNumberOfEntriesInArchive(int expectedEntries) {
+    assertEquals("Number of archive entries", expectedEntries, entries.size());
+  }
+
+  @Override
+  public void assertContentOfEntryInArchive(String entryName, String expectedEntryContent) {
+    List<String> values = entries.get(entryName).stream().map(e -> e.content).collect(Collectors.toList());
+    assertEquals(String.format("Number of archive entries with path  %s", entryName), 1, values.size());
+    assertEquals(String.format("Archive entry %s contents", entryName), expectedEntryContent, values.get(0));
+  }
+
+  @Override
+  public void assertSizeOfEntryInArchive(String entryName, long size) {
+    List<Long> values = entries.get(entryName).stream().map(e -> e.size).collect(Collectors.toList());
+    assertEquals(String.format("Number of archive entries with path %s", entryName), 1, values.size());
+    assertEquals(String.format("Archive entry %s size", entryName), size, (long) values.get(0));
+  }
+
+  @Override
+  public void assertTimeOfEntryInArchive(String entryName, long time) {
+    List<Long> values = entries.get(entryName).stream().map(e -> e.time).collect(Collectors.toList());
+    assertEquals(String.format("Number of archive entries with path  %s", entryName), 1, values.size());
+    assertEquals(String.format("Archive entry %s time", entryName), time, values.get(0).longValue());
+  }
+
+  @Override
+  public void showEntries() {
+    System.out.println();
+    entries.values().forEach(entry -> System.out.println(entry.name + " -> " + entry.size));
+    System.out.println();
+  }
+
+  static class TestEntry {
+
+    String name;
+    String content;
+    long time;
+    long size;
+
+    TestEntry(String name, String content, long time, long size) {
+      this.name = name;
+      this.content = content;
+      this.time = time;
+      this.size = size;
+    }
+  }
+}
+

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/archive/ArchiveValidator.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/archive/ArchiveValidator.java
@@ -1,0 +1,24 @@
+package ca.vanzyl.provisio.archive;
+
+import java.io.IOException;
+
+public interface ArchiveValidator {
+
+  void assertNumberOfEntriesInArchive(int expectedEntries) throws IOException;
+
+  void assertContentOfEntryInArchive(String entryName, String expectedEntryContent) throws IOException;
+
+  void assertSizeOfEntryInArchive(String entryName, long size) throws IOException;
+
+  void assertTimeOfEntryInArchive(String entryName, long time) throws IOException;
+
+  void assertEntryExists(String expectedEntry) throws IOException;
+
+  void assertEntryDoesntExist(String expectedEntry) throws IOException;
+
+  void assertEntries(String... entries) throws IOException;
+
+  void assertSortedEntries(String... entries) throws IOException;
+
+  void showEntries();
+}

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/archive/MultiMap.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/archive/MultiMap.java
@@ -1,0 +1,39 @@
+package ca.vanzyl.provisio.archive;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class MultiMap<K, V> {
+
+  private final Map<K, List<V>> map = new LinkedHashMap<>();
+
+  public void put(K key, V value) {
+    map.computeIfAbsent(key, k -> new ArrayList<>());
+    map.get(key).add(value);
+  }
+
+  public List<V> get(K key) {
+    return map.get(key);
+  }
+
+  public Set<Map.Entry<K, List<V>>> entries() {
+    return map.entrySet();
+  }
+
+  public List<V> values() {
+    return map.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+  }
+
+  public boolean containsKey(K key) {
+    return map.containsKey(key);
+  }
+
+  public int size() {
+    return values().size();
+  }
+}

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/archive/ZipArchiveValidator.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/archive/ZipArchiveValidator.java
@@ -1,0 +1,12 @@
+package ca.vanzyl.provisio.archive;
+
+import ca.vanzyl.provisio.archive.zip.ZipArchiveSource;
+import java.io.File;
+import java.io.IOException;
+
+public class ZipArchiveValidator extends AbstractArchiveValidator {
+
+  public ZipArchiveValidator(File archive) throws IOException {
+    super(new ZipArchiveSource(archive));
+  }
+}

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
@@ -14,8 +14,6 @@ import ca.vanzyl.provisio.model.ProvisioningRequest;
 import ca.vanzyl.provisio.model.ProvisioningResult;
 import ca.vanzyl.provisio.model.Runtime;
 import ca.vanzyl.provisio.model.io.RuntimeReader;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.Before;
@@ -26,14 +24,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import ca.vanzyl.provisio.Actions;
 import ca.vanzyl.provisio.MavenProvisioner;
-import io.tesla.proviso.archive.ArchiveValidator;
-import io.tesla.proviso.archive.ZipArchiveValidator;
+import ca.vanzyl.provisio.archive.ArchiveValidator;
+import ca.vanzyl.provisio.archive.ZipArchiveValidator;
 
 public class ProvisioTest {
 
@@ -163,12 +159,12 @@ public class ProvisioTest {
     request.setRuntimeDescriptor(parseDescriptor(descriptor));
     // If there is a provisio.properties file for inserting values use it
     File propertiesFile = new File(projectBasedir, "provisio.properties");
-    Map<String, String> provisioProperties = Maps.newHashMap();
+    Map<String, String> provisioProperties = new HashMap<>();
     if (propertiesFile.exists()) {
       Properties properties = new Properties();
       try (InputStream is = new FileInputStream(propertiesFile)) {
         properties.load(is);
-        provisioProperties.putAll(Maps.fromProperties(properties));
+        properties.forEach((k, v) -> provisioProperties.put(String.valueOf(k), String.valueOf(v)));
       }
     }
     provisioProperties.put("basedir", basedir.getAbsolutePath());
@@ -197,9 +193,9 @@ public class ProvisioTest {
   }
   
   public static Runtime parseDescriptor(File descriptor) throws Exception {
-    RuntimeReader parser = new RuntimeReader(Actions.defaultActionDescriptors(), Maps.<String, String>newHashMap());
+    RuntimeReader parser = new RuntimeReader(Actions.defaultActionDescriptors(), new HashMap<>());
     try (InputStream is = new FileInputStream(descriptor)) {
-      return parser.read(is, ImmutableMap.of("basedir", descriptor.getParentFile().getAbsolutePath()));
+      return parser.read(is, Map.of("basedir", descriptor.getParentFile().getAbsolutePath()));
     }
   }
 

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/its/ResolutionSystem.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/its/ResolutionSystem.java
@@ -1,6 +1,7 @@
 package ca.vanzyl.provisio.its;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
@@ -19,30 +20,23 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.transfer.AbstractTransferListener;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 
-import com.google.common.collect.Lists;
-
-import io.takari.aether.connector.AetherRepositoryConnectorFactory;
-
 public class ResolutionSystem {
 
-  private File localRepository;
-  private RepositorySystem system;
-  private RepositorySystemSession session;
-  private List<RemoteRepository> remoteRepositories;
+  private final File localRepository;
+  private final RepositorySystem system;
+  private final RepositorySystemSession session;
+  private final List<RemoteRepository> remoteRepositories;
 
   public ResolutionSystem(File localRepository) {
-    DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
-    locator.addService(RepositoryConnectorFactory.class, AetherRepositoryConnectorFactory.class);
-    locator.addService(TransporterFactory.class, FileTransporterFactory.class);    
-    locator.addService(FileProcessor.class, DefaultFileProcessor.class);
     this.localRepository = localRepository;
-    this.system = locator.getService(RepositorySystem.class);
+    this.system = new RepositorySystemSupplier().get();
     this.session = repositorySystemSession();
-    this.remoteRepositories = Lists.newArrayList();
+    this.remoteRepositories = new ArrayList<>();
   }
 
   public ArtifactType getArtifactType(String typeId) {

--- a/provisio-maven-plugin/pom.xml
+++ b/provisio-maven-plugin/pom.xml
@@ -49,10 +49,6 @@
       <version>${incrementalbuild.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/Provisio.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/Provisio.java
@@ -19,10 +19,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -36,9 +33,6 @@ import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.util.FileUtils;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import ca.vanzyl.provisio.Actions;
 
@@ -54,14 +48,14 @@ public class Provisio {
   }
 
   public List<Runtime> findDescriptors(File descriptorDirectory, MavenProject project) {
-    List<Runtime> runtimes = Lists.newArrayList();
+    List<Runtime> runtimes = new ArrayList<>();
     runtimes.addAll(findDescriptorsInFileSystem(descriptorDirectory, project));
     runtimes.addAll(findDescriptorsForPackagingTypeInExtensionRealms(project));
     return runtimes;
   }
 
   public List<Runtime> findDescriptorsInFileSystem(File descriptorDirectory, MavenProject project) {
-    List<Runtime> runtimes = Lists.newArrayList();
+    List<Runtime> runtimes = new ArrayList<>();
     if (descriptorDirectory.exists()) {
       try {
         List<File> descriptors = FileUtils.getFiles(descriptorDirectory, "*.xml", null);
@@ -77,7 +71,7 @@ public class Provisio {
   }
 
   public List<Runtime> findDescriptorsForPackagingTypeInExtensionRealms(MavenProject project) {
-    List<Runtime> runtimes = Lists.newArrayList();
+    List<Runtime> runtimes = new ArrayList<>();
     if (project.getClassRealm() != null) {
       Collection<ClassRealm> extensionRealms = project.getClassRealm().getImportRealms();
       if (extensionRealms != null) {
@@ -96,7 +90,7 @@ public class Provisio {
 
   public Runtime parseDescriptor(InputStream inputStream, MavenProject project) {
     RuntimeReader parser = new RuntimeReader(Actions.defaultActionDescriptors(), versionMap(project));
-    Map<String, String> variables = Maps.newHashMap();
+    Map<String, String> variables = new HashMap<>();
     variables.putAll((Map) getPropertiesWithSystemOverrides(project));
     variables.put("project.version", project.getVersion());
     variables.put("project.groupId", project.getGroupId());
@@ -117,7 +111,7 @@ public class Provisio {
   // The version map to use when versions are not specified for the artifacts in the assembly/runtime document.
   //
   private Map<String, String> versionMap(MavenProject project) {
-    Map<String, String> versionMap = Maps.newHashMap();
+    Map<String, String> versionMap = new HashMap<>();
     DependencyManagement dependencyManagement = project.getDependencyManagement();
     if (dependencyManagement != null) {
       for (Dependency managedDependency : project.getDependencyManagement().getDependencies()) {
@@ -135,7 +129,7 @@ public class Provisio {
   }
 
   public List<String> getManagedDependencies(MavenProject project) {
-    List<String> managedDependencies = Lists.newArrayList();
+    List<String> managedDependencies = new ArrayList<>();
     DependencyManagement dependencyManagement = project.getDependencyManagement();
     if (dependencyManagement != null) {
       for (Dependency managedDependency : project.getDependencyManagement().getDependencies()) {

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningLifecycleParticipant.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningLifecycleParticipant.java
@@ -18,10 +18,7 @@ package ca.vanzyl.maven.plugins.provisio;
 import ca.vanzyl.provisio.model.Runtime;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -34,8 +31,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-
-import com.google.common.collect.Sets;
 
 @Singleton
 @Named("ProvisioningLifecycleParticipant")
@@ -110,7 +105,7 @@ public class ProvisioningLifecycleParticipant extends AbstractMavenLifecyclePart
     // For all our descriptors we need to find all the artifacts requested that might refer to projects
     // in the current build so we can influence build ordering.
     //
-    Set<String> dependencyCoordinatesInVersionlessForm = Sets.newHashSet();
+    Set<String> dependencyCoordinatesInVersionlessForm = new HashSet<>();
 
     List<Runtime> runtimes = provisio.findDescriptorsInFileSystem(descriptorDirectory, project);
     for (Runtime runtime : runtimes) {

--- a/provisio-maven/pom.xml
+++ b/provisio-maven/pom.xml
@@ -30,10 +30,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>
@@ -45,15 +41,32 @@
       <groupId>ca.vanzyl</groupId>
       <artifactId>provisio-core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
       <version>${sisuVersion}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>failureaccess</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Changes:
* use latest Takari parent POM
* compile against Maven 3.9.6 (but prerequisite is unchanged), align to stuff in 3.9.6 maven
* get rid of Guava
* update stale dependencies
* copy relevant classes from takari-archiver as `tests` classified artifact is not published anymore
