### PR TITLE
Add test for transitive dependency with local test scope

### DIFF
--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ProvisioningIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ProvisioningIntegrationTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015-2020 Jason van Zyl
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.vanzyl.maven.plugins.provisio;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3", "3.8.4", "3.9.6"})
+@SuppressWarnings({"JUnitTestNG", "PublicField"})
+public class ProvisioningIntegrationTest
+{
+    @Rule
+    public final TestResources resources = new TestResources();
+
+    public final MavenRuntime maven;
+
+    public ProvisioningIntegrationTest(MavenRuntimeBuilder mavenBuilder)
+            throws Exception
+    {
+        this.maven = mavenBuilder.withCliOptions("-B", "-U").build();
+    }
+
+    @Test
+    public void testTransitiveWithLocalTestScope()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("transitive-test");
+        maven.forProject(basedir)
+                .execute("provisio:provision")
+                .assertErrorFreeLog();
+
+        File libdir = new File(basedir, "target/test-1.0/lib");
+        assertTrue("guice exists", new File(libdir, "guice-7.0.0.jar").isFile());
+        assertTrue("guava exists", new File(libdir, "guava-31.0.1-jre.jar").isFile());
+    }
+}

--- a/provisio-maven-plugin/src/test/projects/transitive-test/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/transitive-test/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <packaging>provisio</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>7.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>${it-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/provisio-maven-plugin/src/test/projects/transitive-test/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/transitive-test/src/main/provisio/provisio.xml
@@ -1,0 +1,3 @@
+<runtime>
+    <artifactSet to="/lib" ref="runtime.classpath" />
+</runtime>


### PR DESCRIPTION
This example project has a direct dependencies on Guice in compile scope and Guava in test scope. Guice depends on Guava, so the runtime classpath should include Guava, as it is required at runtime.

Note that this test currently fails on all versions of Maven, even though `ProvisioningMojo` requests `compile+runtime`.