### PR TITLE
Incomplete runtime classpath

### DIFF
--- a/provisio-maven-plugin/pom.xml
+++ b/provisio-maven-plugin/pom.xml
@@ -108,6 +108,11 @@
       <artifactId>maven-resolver-impl</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <!-- NOT provided: to work with 3.8 and 3.9 -->
+    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/Provisio.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/Provisio.java
@@ -147,8 +147,8 @@ public class Provisio {
   }
 
   public String toCoordinate(Dependency d) {
-    StringBuffer sb = new StringBuffer().append(d.getGroupId()).append(":").append(d.getArtifactId()).append(":").append(d.getType());
-    if (d.getClassifier() != null && d.getClassifier().isEmpty() == false) {
+    StringBuilder sb = new StringBuilder().append(d.getGroupId()).append(":").append(d.getArtifactId()).append(":").append(d.getType());
+    if (d.getClassifier() != null && !d.getClassifier().isEmpty()) {
       sb.append(":").append(d.getClassifier());
     }
     sb.append(":").append(d.getVersion());
@@ -156,8 +156,8 @@ public class Provisio {
   }
 
   public String toVersionlessCoordinate(Dependency d) {
-    StringBuffer sb = new StringBuffer().append(d.getGroupId()).append(":").append(d.getArtifactId()).append(":").append(d.getType());
-    if (d.getClassifier() != null && d.getClassifier().isEmpty() == false) {
+    StringBuilder sb = new StringBuilder().append(d.getGroupId()).append(":").append(d.getArtifactId()).append(":").append(d.getType());
+    if (d.getClassifier() != null && !d.getClassifier().isEmpty()) {
       sb.append(":").append(d.getClassifier());
     }
     return sb.toString();
@@ -165,8 +165,6 @@ public class Provisio {
 
   public String toVersionlessCoordinate(MavenProject project) {
     String extension = artifactHandlerManager.getArtifactHandler(project.getPackaging()).getExtension();
-    StringBuffer sb = new StringBuffer().append(project.getGroupId()).append(":").append(project.getArtifactId()).append(":").append(extension);
-    return sb.toString();
+    return project.getGroupId() + ":" + project.getArtifactId() + ":" + extension;
   }
-
 }

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ProvisioningMojo.java
@@ -24,15 +24,13 @@ import ca.vanzyl.provisio.model.ProvisioningRequest;
 import ca.vanzyl.provisio.model.ProvisioningResult;
 import ca.vanzyl.provisio.model.Runtime;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import ca.vanzyl.provisio.MavenProvisioner;
 
-@Mojo(name = "provision", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "provision", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class ProvisioningMojo extends BaseMojo {
 
   @Parameter(defaultValue = "false", property = "skipProvision")
@@ -41,6 +39,7 @@ public class ProvisioningMojo extends BaseMojo {
   @Parameter(defaultValue = "${project.build.directory}/${project.artifactId}-${project.version}")
   private File outputDirectory;
 
+  @Override
   public void execute() throws MojoExecutionException {
     if (skipProvision) {
       getLog().info("Skipping provision");

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/ValidatorMojo.java
@@ -25,7 +25,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -34,7 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mojo(name = "validateDependencies", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "validateDependencies", threadSafe = true)
 public class ValidatorMojo
         extends BaseMojo
 {
@@ -44,6 +43,7 @@ public class ValidatorMojo
     @Parameter(required = true, property = "pomFile", defaultValue = "${basedir}/pom.xml")
     private File pomFile;
 
+    @Override
     public void execute()
             throws MojoExecutionException, MojoFailureException
     {

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/GeneratorIntegrationTest.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertArrayEquals;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.6.3", "3.8.4"})
+@MavenVersions({"3.6.3", "3.8.8", "3.9.6"})
 @SuppressWarnings({"JUnitTestNG", "PublicField"})
 public class GeneratorIntegrationTest
 {

--- a/provisio-maven-plugin/src/test/projects/transitive-test/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/transitive-test/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <packaging>provisio</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Case1: runtime CP should contain runtime deps even if they are in test scope -->
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>7.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Case2: provided scope should not come in even if is runtime dep of something in graph -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.11</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.11</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>${it-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/provisio-maven-plugin/src/test/projects/transitive-test/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/transitive-test/src/main/provisio/provisio.xml
@@ -1,0 +1,3 @@
+<runtime>
+    <artifactSet to="/lib" ref="runtime.classpath" />
+</runtime>


### PR DESCRIPTION
Similar fix to m-assembly-p: do not rely on Maven Core to provide
"runtime" resolution scope as it have issues, see:
https://issues.apache.org/jira/browse/MNG-8041

Instead, use Resolver APIs directly to get what is needed.
Contains several minor code improvements across Provisio
maven-plugin module.

Other changes in this PR:
* added support for -X to dump proviso graph
* marked Mojos as thread safe, removed now unneeded ask for resolution
  (as they use Resolver APIs)

Contains IT from https://github.com/jvanzyl/provisio/pull/70
Fixes https://github.com/jvanzyl/provisio/issues/71