### PR TITLE
Add git blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+8f8c32cffb5b98f58a61fd9e90f4e918d6c4f151
+


### PR DESCRIPTION
Reformatting sources would smear all the blame, this just makes it right.