### PR TITLE
Fix provision w/ Resolver expectations

### DIFF
--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/alter/AlterAction.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/alter/AlterAction.java
@@ -33,6 +33,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
+import java.util.Set;
 import javax.inject.Named;
 import org.codehaus.plexus.util.FileUtils;
 import org.slf4j.Logger;
@@ -72,8 +73,8 @@ public class AlterAction implements ProvisioningAction {
             if (inserts != null) {
                 for (Insert insert : inserts) {
                     for (ProvisioArtifact insertArtifact : insert.getArtifacts()) {
-                        provisioner.resolveArtifact(context, insertArtifact);
-                        File source = insertArtifact.getFile();
+                        Set<ProvisioArtifact> resolved = provisioner.resolveArtifact(context, insertArtifact);
+                        File source = resolved.iterator().next().getFile();
                         File target = new File(unpackDirectory, insertArtifact.getName());
                         Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
                     }

--- a/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/BaseMojo.java
+++ b/provisio-maven-plugin/src/main/java/ca/vanzyl/maven/plugins/provisio/BaseMojo.java
@@ -94,8 +94,8 @@ public abstract class BaseMojo extends AbstractMojo {
                 && projectArtifact.getFile().getName().endsWith(".jar")
                 && projectArtifact.getFile().exists()) {
             jarArtifact = new ProvisioArtifact(
-                    project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion());
-            jarArtifact.setFile(projectArtifact.getFile());
+                            project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion())
+                    .setFile(projectArtifact.getFile());
         }
         return jarArtifact;
     }

--- a/provisio-model/src/main/java/ca/vanzyl/provisio/model/ProvisioArtifact.java
+++ b/provisio-model/src/main/java/ca/vanzyl/provisio/model/ProvisioArtifact.java
@@ -16,9 +16,11 @@
 package ca.vanzyl.provisio.model;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.eclipse.aether.artifact.AbstractArtifact;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -47,16 +49,31 @@ public class ProvisioArtifact extends AbstractArtifact {
         this.name = name;
     }
 
+    public ProvisioArtifact(Artifact a) {
+        this.delegate = a;
+    }
+
+    private ProvisioArtifact(
+            String name,
+            List<ProvisioningAction> actions,
+            Artifact delegate,
+            String coordinate,
+            List<String> exclusions,
+            String reference) {
+        this.name = name;
+        this.actions = actions;
+        this.delegate = delegate;
+        this.coordinate = coordinate;
+        this.exclusions = exclusions;
+        this.reference = reference;
+    }
+
     public String getName() {
         return name;
     }
 
     public String getReference() {
         return reference;
-    }
-
-    public ProvisioArtifact(Artifact a) {
-        this.delegate = a;
     }
 
     public String getCoordinate() {
@@ -78,7 +95,7 @@ public class ProvisioArtifact extends AbstractArtifact {
                 .append(getArtifactId())
                 .append(":")
                 .append(getExtension());
-        if (getClassifier() != null && getClassifier().isEmpty() == false) {
+        if (getClassifier() != null && !getClassifier().isEmpty()) {
             sb.append(":").append(getClassifier());
         }
         return sb.toString();
@@ -115,9 +132,12 @@ public class ProvisioArtifact extends AbstractArtifact {
     }
 
     @Override
-    public Artifact setVersion(String version) {
-        delegate = delegate.setVersion(version);
-        return this;
+    public ProvisioArtifact setVersion(String version) {
+        Artifact newArtifact = delegate.setVersion(version);
+        if (this.delegate == newArtifact) {
+            return this;
+        }
+        return new ProvisioArtifact(name, actions, newArtifact, coordinate, exclusions, reference);
     }
 
     @Override
@@ -146,9 +166,25 @@ public class ProvisioArtifact extends AbstractArtifact {
     }
 
     @Override
-    public Artifact setFile(File file) {
-        delegate = delegate.setFile(file);
-        return this;
+    public ProvisioArtifact setFile(File file) {
+        Artifact newArtifact = delegate.setFile(file);
+        if (this.delegate == newArtifact) {
+            return this;
+        }
+        return new ProvisioArtifact(name, actions, newArtifact, coordinate, exclusions, reference);
+    }
+
+    public Path getPath() {
+        File file = getFile();
+        return file != null ? file.toPath() : null;
+    }
+
+    public Artifact setPath(Path path) {
+        Path current = getPath();
+        if (Objects.equals(current, path)) {
+            return this;
+        }
+        return setFile(path != null ? path.toFile() : null);
     }
 
     @Override
@@ -162,9 +198,12 @@ public class ProvisioArtifact extends AbstractArtifact {
     }
 
     @Override
-    public Artifact setProperties(Map<String, String> properties) {
-        delegate = delegate.setProperties(properties);
-        return this;
+    public ProvisioArtifact setProperties(Map<String, String> properties) {
+        Artifact newArtifact = delegate.setProperties(properties);
+        if (this.delegate == newArtifact) {
+            return this;
+        }
+        return new ProvisioArtifact(name, actions, newArtifact, coordinate, exclusions, reference);
     }
 
     @Override


### PR DESCRIPTION
Provisio expects same Artifact instance back from resolving it pushed as parameter, but BF collection violates this. There  as an if/else for this case, but else branch had an information loss, where resolver provisio artifact w/ actions like unpack would lost unpack step.

Another fix was that ProvisioArtifact violated immutability, and was handled on many places as mutable (like MavenArtifact).

This expection breaks for example provisio when BF collector is used, that is the default in Maven4, but can be activated in Maven 3.9.x as well (`-Daether.dependencyCollector.impl=bf`).

Fixes #90