### PR TITLE
Add groupId to artifacts filenames on disk

### DIFF
--- a/provisio-core/pom.xml
+++ b/provisio-core/pom.xml
@@ -80,6 +80,11 @@
       <version>2.7.5</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.16.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>
       <artifactId>compiler</artifactId>
     </dependency>

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/ProvisioUtils.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/ProvisioUtils.java
@@ -16,6 +16,7 @@
 package ca.vanzyl.provisio;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.abbreviateMiddle;
 
 import ca.vanzyl.provisio.model.ProvisioArtifact;
 import java.io.IOException;
@@ -23,6 +24,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class ProvisioUtils {
+    private static final int MAXIMUM_FILENAME_LENGTH = 64;
+    private static final String GROUP_ARTIFACT_SEPARATOR = "_";
+    private static final String ELLIPSIS = "...";
 
     public static String coordinateToPath(ProvisioArtifact a) {
 
@@ -53,5 +57,18 @@ public class ProvisioUtils {
             to.write(buf, 0, r);
             total += (long) r;
         }
+    }
+
+    public static String targetArtifactFileName(ProvisioArtifact artifact, String name) {
+        if (artifact.getName() == null && name == null) {
+            throw new IllegalArgumentException("Artifact name and file name are both null");
+        }
+
+        String filenameSuffix = (artifact.getName() != null ? artifact.getName() : name);
+        int remaining = MAXIMUM_FILENAME_LENGTH - filenameSuffix.length() - GROUP_ARTIFACT_SEPARATOR.length();
+        if (remaining <= 0) {
+            return abbreviateMiddle(filenameSuffix, ELLIPSIS, MAXIMUM_FILENAME_LENGTH);
+        }
+        return abbreviateMiddle(artifact.getGroupId(), ELLIPSIS, remaining) + GROUP_ARTIFACT_SEPARATOR + filenameSuffix;
     }
 }

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/WriteToDiskAction.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/WriteToDiskAction.java
@@ -15,6 +15,7 @@
  */
 package ca.vanzyl.provisio.action.artifact;
 
+import static ca.vanzyl.provisio.ProvisioUtils.targetArtifactFileName;
 import static java.util.Objects.requireNonNull;
 
 import ca.vanzyl.provisio.ProvisioningException;
@@ -29,7 +30,6 @@ import javax.inject.Named;
 
 @Named("write")
 public class WriteToDiskAction implements ProvisioningAction {
-
     private ProvisioArtifact artifact;
     private File outputDirectory;
 
@@ -43,8 +43,7 @@ public class WriteToDiskAction implements ProvisioningAction {
     public void execute(ProvisioningContext context) {
         File file = artifact.getFile();
         if (file != null) {
-            String targetName = artifact.getName() != null ? artifact.getName() : file.getName();
-            copy(file, new File(outputDirectory, targetName));
+            copy(file, new File(outputDirectory, targetArtifactFileName(artifact, file.getName())));
         }
     }
 

--- a/provisio-core/src/test/java/ca/vanzyl/provisio/ProvisioUtilsTest.java
+++ b/provisio-core/src/test/java/ca/vanzyl/provisio/ProvisioUtilsTest.java
@@ -1,6 +1,7 @@
 package ca.vanzyl.provisio;
 
 import static ca.vanzyl.provisio.ProvisioUtils.coordinateToPath;
+import static ca.vanzyl.provisio.ProvisioUtils.targetArtifactFileName;
 import static org.junit.Assert.assertEquals;
 
 import ca.vanzyl.provisio.model.ProvisioArtifact;
@@ -11,8 +12,29 @@ public class ProvisioUtilsTest {
     @Test
     public void validateCoordinateToPath() {
 
-        ProvisioArtifact artifact = new ProvisioArtifact("io.prestosql:presto-main:332");
+        ProvisioArtifact artifact = new ProvisioArtifact("io.trinodb:trino-main:445");
         String path = coordinateToPath(artifact);
-        assertEquals("presto-main-332.jar", path);
+        assertEquals("trino-main-445.jar", path);
+    }
+
+    @Test
+    public void validateArtifactFilenames() {
+        assertEquals(
+                "io.trinodb_trino.jar",
+                targetArtifactFileName(new ProvisioArtifact("io.trinodb:trino-main:445"), "trino.jar"));
+        assertEquals(
+                "io.trinodb_trino-main-445.jar",
+                targetArtifactFileName(new ProvisioArtifact("io.trinodb:trino-main:455"), "trino-main-445.jar"));
+        assertEquals(
+                "org.wso2.carbon.identity.user.s....configuration.stub-7.4.15.jar",
+                targetArtifactFileName(
+                        new ProvisioArtifact(
+                                "org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.stub:7.4.15"),
+                        "org.wso2.carbon.identity.user.store.configuration.stub-7.4.15.jar"));
+        assertEquals(
+                "org.wso2.ca...y.framework_org.wso2.carbon.user.mgt.ui-7.4.15.jar",
+                targetArtifactFileName(
+                        new ProvisioArtifact("org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.ui:7.4.15"),
+                        "org.wso2.carbon.user.mgt.ui-7.4.15.jar"));
     }
 }

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
@@ -93,9 +93,9 @@ public class ProvisioTest {
         String name = "it-0006";
         deleteOutputDirectory(name);
         ProvisioningResult result = provision(name);
-        assertFileExists(result, "lib/maven-core-3.3.9.jar");
-        assertFileDoesntExists(result, "lib/plexus-utils-3.0.22.jar");
-        assertFileDoesntExists(result, "lib/maven-model-3.3.9.jar");
+        assertFileExists(result, "lib/org.apache.maven_maven-core-3.3.9.jar");
+        assertFileDoesntExists(result, "lib/org.codehaus.plexus_plexus-utils-3.0.22.jar");
+        assertFileDoesntExists(result, "lib/org.apache.maven_maven-model-3.3.9.jar");
     }
 
     @Test
@@ -103,13 +103,13 @@ public class ProvisioTest {
         String name = "it-0007";
         deleteOutputDirectory(name);
         ProvisioningResult result = provision(name);
-        assertFileExists(result, "lib/modello-core-1.8.3.jar");
-        assertFileExists(result, "lib/maven-core-3.3.9.jar");
+        assertFileExists(result, "lib/org.codehaus.modello_modello-core-1.8.3.jar");
+        assertFileExists(result, "lib/org.apache.maven_maven-core-3.3.9.jar");
         // excluded from maven
-        assertFileDoesntExists(result, "lib/plexus-utils-3.0.22.jar");
-        assertFileDoesntExists(result, "lib/maven-model-3.3.9.jar");
+        assertFileDoesntExists(result, "lib/org.codehaus.plexus_plexus-utils-3.0.22.jar");
+        assertFileDoesntExists(result, "lib/org.apache.maven_maven-model-3.3.9.jar");
         // excluded from modello
-        assertFileDoesntExists(result, "lib/plexus-utils-3.0.13.jar");
+        assertFileDoesntExists(result, "lib/org.codehaus.plexus_plexus-utils-3.0.13.jar");
     }
 
     @Test

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ProvisioningIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ProvisioningIntegrationTest.java
@@ -50,9 +50,26 @@ public class ProvisioningIntegrationTest {
                 .assertErrorFreeLog();
 
         File libdir = new File(basedir, "target/test-1.0/lib");
-        assertTrue("guice exists", new File(libdir, "guice-7.0.0.jar").isFile());
-        assertTrue("guava exists", new File(libdir, "guava-31.0.1-jre.jar").isFile());
-        assertFalse("slf4j-api not exists", new File(libdir, "slf4j-api-2.0.11.jar").isFile());
-        assertTrue("slf4j-simple exists", new File(libdir, "slf4j-simple-2.0.11.jar").isFile());
+        assertTrue("guice exists", new File(libdir, "com.google.inject_guice-7.0.0.jar").isFile());
+        assertTrue("guava exists", new File(libdir, "com.google.guava_guava-31.0.1-jre.jar").isFile());
+        assertFalse("slf4j-api not exists", new File(libdir, "org.slf4j_slf4j-api-2.0.11.jar").isFile());
+        assertTrue("slf4j-simple exists", new File(libdir, "org.slf4j_slf4j-simple-2.0.11.jar").isFile());
+    }
+
+    @Test
+    public void testConflictingArtifacts() throws Exception {
+        File basedir = resources.getBasedir("conflicting-filenames");
+        maven.forProject(basedir)
+                .withCliOption("-X")
+                .execute("provisio:provision")
+                .assertErrorFreeLog();
+
+        File libdir = new File(basedir, "target/test-1.0/lib");
+        assertTrue(
+                "io.opentelemetry:opentelemetry-semconv exists",
+                new File(libdir, "io.opentelemetry_opentelemetry-semconv-1.27.0-alpha.jar").isFile());
+        assertTrue(
+                "io.opentelemetry.semconv:opentelemetry-semconv exists too",
+                new File(libdir, "io.opentelemetry.semconv_opentelemetry-semconv-1.27.0-alpha.jar").isFile());
     }
 }

--- a/provisio-maven-plugin/src/test/projects/conflicting-filenames/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/conflicting-filenames/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <packaging>provisio</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- ideally artifacts should not have the same artifactId and version but conflicts can happen -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.27.0-alpha</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.27.0-alpha</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>${it-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/provisio-maven-plugin/src/test/projects/conflicting-filenames/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/conflicting-filenames/src/main/provisio/provisio.xml
@@ -1,0 +1,3 @@
+<runtime>
+    <artifactSet to="/lib" ref="runtime.classpath" />
+</runtime>


### PR DESCRIPTION
This is rare but not impossible for a project to have two artifacts that have the same artifactId and version which causes provisio to keep only a single file for <artifactSet>.

Fix for https://github.com/trinodb/trino/issues/23187