### PR TITLE
Target file handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <surefire.runOrder>alphabetical</surefire.runOrder>
     <surefire.mem>-Xmx256m</surefire.mem>
     <mavenVersion>3.9.9</mavenVersion>
-    <takariArchiverVersion>1.0.0</takariArchiverVersion>
+    <takariArchiverVersion>1.0.1</takariArchiverVersion>
     <!-- Align with Aether version used in $mavenVersion -->
     <aetherVersion>1.9.22</aetherVersion>
     <!-- Align with Sisu version used in $mavenVersion -->
@@ -73,6 +73,16 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.16.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>4.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-xml</artifactId>
+        <version>3.0.1</version>
       </dependency>
 
       <dependency>

--- a/provisio-core/pom.xml
+++ b/provisio-core/pom.xml
@@ -80,11 +80,6 @@
       <version>2.7.5</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.17.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>
       <artifactId>compiler</artifactId>
     </dependency>

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/ProvisioVariables.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/ProvisioVariables.java
@@ -67,8 +67,6 @@ public final class ProvisioVariables {
      */
     public static final String GA_MAX_FILE_NAME_LENGTH = VARIABLE_PREFIX + "maxFileNameLength";
 
-    //
-
     public static boolean allowTargetOverwrite(ProvisioningContext context) {
         return Boolean.parseBoolean(
                 context.getVariables().getOrDefault(ALLOW_TARGET_OVERWRITE, Boolean.FALSE.toString()));

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/ProvisioVariables.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/ProvisioVariables.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015-2024 Jason van Zyl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ca.vanzyl.provisio;
+
+import ca.vanzyl.provisio.model.ProvisioningContext;
+
+/**
+ * Knobs and switches to control Proviso behaviour.
+ */
+public final class ProvisioVariables {
+    private ProvisioVariables() {}
+
+    private static final String VARIABLE_PREFIX = "provisio.";
+
+    /**
+     * A boolean flag denoting that user allows "overwrite" to happen in case of conflicting target files. If set
+     * to {@code true} Provisio will overwrite target files (but will warn). If set to {@code false} Provisio will
+     * fail provisioning, if overwrite is about to happen. Defaults to {@code false}.
+     * <p>
+     * Note: Provisio older versions did silently overwrite conflicting target files. This change now makes Provisio
+     * fail. If you need old behaviour, make this variable {@code true} and tolerate warnings. Ideally you want to
+     * resolve this state.
+     */
+    public static final String ALLOW_TARGET_OVERWRITE = VARIABLE_PREFIX + "allowTargetOverwrite";
+
+    /**
+     * Option to control the "fallback" target file naming, used in cases when no explicit artifact name was given
+     * (in XML using {@code artifact as="..."} construct). Originally Provisio used resolved artifact filename,
+     * but it may lead to conflicts (same named file may exist under different groupId). The alternative option is
+     * to "factor in" Artifact groupId into target file name, making it unique even in case of conflict.
+     * Default value is {@link FallBackTargetFileNameMode#ARTIFACT_FILE_NAME}.
+     *
+     * @see #ALLOW_TARGET_OVERWRITE
+     */
+    public static final String FALLBACK_TARGET_FILE_NAME_MODE = VARIABLE_PREFIX + "fallbackTargetFileNameMode";
+
+    /**
+     * The enum values for {@link #FALLBACK_TARGET_FILE_NAME_MODE}.
+     */
+    public enum FallBackTargetFileNameMode {
+        ARTIFACT_FILE_NAME,
+        GA
+    }
+
+    /**
+     * The separator to use between groupId and artifactId when in mode {@link FallBackTargetFileNameMode#GA},
+     * defaults to underscore (@code "_").
+     */
+    public static final String GA_SEPARATOR = VARIABLE_PREFIX + "gaSeparator";
+
+    /**
+     * The maximum filename length to allow when in mode {@link FallBackTargetFileNameMode#GA},
+     * defaults to 64.
+     */
+    public static final String GA_MAX_FILE_NAME_LENGTH = VARIABLE_PREFIX + "maxFileNameLength";
+
+    //
+
+    public static boolean allowTargetOverwrite(ProvisioningContext context) {
+        return Boolean.parseBoolean(
+                context.getVariables().getOrDefault(ALLOW_TARGET_OVERWRITE, Boolean.FALSE.toString()));
+    }
+
+    public static FallBackTargetFileNameMode fallbackTargetFileNameMode(ProvisioningContext context) {
+        return FallBackTargetFileNameMode.valueOf(context.getVariables()
+                .getOrDefault(FALLBACK_TARGET_FILE_NAME_MODE, FallBackTargetFileNameMode.ARTIFACT_FILE_NAME.name()));
+    }
+
+    public static String gaSeparator(ProvisioningContext context) {
+        return context.getVariables().getOrDefault(GA_SEPARATOR, "_");
+    }
+
+    public static int gaMaxFileNameLength(ProvisioningContext context) {
+        return Integer.parseInt(context.getVariables().getOrDefault(GA_MAX_FILE_NAME_LENGTH, "64"));
+    }
+}

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/WriteToDiskAction.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/WriteToDiskAction.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 @Named("write")
 public class WriteToDiskAction implements ProvisioningAction {
     private static final Logger logger = LoggerFactory.getLogger(WriteToDiskAction.class);
-    private static final int BUFFER_SIZE = 32 * 1024;
 
     private final ProvisioArtifact artifact;
     private final File outputDirectory;
@@ -69,9 +68,9 @@ public class WriteToDiskAction implements ProvisioningAction {
                             "Conflict: artifact " + artifact + " would overwrite existing file: " + targetPath);
                 }
             }
-            try (CachingOutputStream outputStream = new CachingOutputStream(target.toPath(), BUFFER_SIZE);
+            try (CachingOutputStream outputStream = new CachingOutputStream(target.toPath());
                     BufferedInputStream inputStream =
-                            new BufferedInputStream(new FileInputStream(artifact.getFile()), BUFFER_SIZE)) {
+                            new BufferedInputStream(new FileInputStream(artifact.getFile()))) {
                 inputStream.transferTo(outputStream);
                 outputStream.close();
                 if (outputStream.isModified()) {

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/WriteToDiskAction.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/WriteToDiskAction.java
@@ -23,17 +23,20 @@ import ca.vanzyl.provisio.ProvisioningException;
 import ca.vanzyl.provisio.model.ProvisioArtifact;
 import ca.vanzyl.provisio.model.ProvisioningAction;
 import ca.vanzyl.provisio.model.ProvisioningContext;
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import javax.inject.Named;
+import org.codehaus.plexus.util.io.CachingOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Named("write")
 public class WriteToDiskAction implements ProvisioningAction {
-    private static Logger logger = LoggerFactory.getLogger(WriteToDiskAction.class);
+    private static final Logger logger = LoggerFactory.getLogger(WriteToDiskAction.class);
+    private static final int BUFFER_SIZE = 32 * 1024;
 
     private final ProvisioArtifact artifact;
     private final File outputDirectory;
@@ -58,18 +61,22 @@ public class WriteToDiskAction implements ProvisioningAction {
         File target = new File(outputDirectory, targetPath);
         try {
             Files.createDirectories(target.getParentFile().toPath());
-            if (ProvisioVariables.allowTargetOverwrite(context)) {
-                if (Files.isRegularFile(target.toPath())) {
-                    logger.warn("Conflict: artifact {} overwrote existing file {}", artifact, targetPath);
-                }
-                Files.copy(artifact.getFile().toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            } else {
-                if (Files.isRegularFile(target.toPath())) {
+            if (Files.exists(target.toPath())) {
+                if (ProvisioVariables.allowTargetOverwrite(context)) {
+                    logger.warn("Conflict: artifact {} overwrites existing file {}", artifact, targetPath);
+                } else {
                     throw new ProvisioningException(
                             "Conflict: artifact " + artifact + " would overwrite existing file: " + targetPath);
                 }
-                logger.debug("Copying {} -> {}", artifact, targetPath);
-                Files.copy(artifact.getFile().toPath(), target.toPath());
+            }
+            try (CachingOutputStream outputStream = new CachingOutputStream(target.toPath(), BUFFER_SIZE);
+                    BufferedInputStream inputStream =
+                            new BufferedInputStream(new FileInputStream(artifact.getFile()), BUFFER_SIZE)) {
+                inputStream.transferTo(outputStream);
+                outputStream.close();
+                if (outputStream.isModified()) {
+                    target.setLastModified(artifact.getFile().lastModified());
+                }
             }
         } catch (IOException e) {
             throw new ProvisioningException("Error copying " + source + " to " + targetPath, e);

--- a/provisio-core/src/test/java/ca/vanzyl/provisio/ProvisioUtilsTest.java
+++ b/provisio-core/src/test/java/ca/vanzyl/provisio/ProvisioUtilsTest.java
@@ -5,6 +5,10 @@ import static ca.vanzyl.provisio.ProvisioUtils.targetArtifactFileName;
 import static org.junit.Assert.assertEquals;
 
 import ca.vanzyl.provisio.model.ProvisioArtifact;
+import ca.vanzyl.provisio.model.ProvisioningContext;
+import ca.vanzyl.provisio.model.ProvisioningRequest;
+import ca.vanzyl.provisio.model.ProvisioningResult;
+import java.util.HashMap;
 import org.junit.Test;
 
 public class ProvisioUtilsTest {
@@ -18,22 +22,61 @@ public class ProvisioUtilsTest {
     }
 
     @Test
-    public void validateArtifactFilenames() {
+    public void validateArtifactFilenames_A() {
+        ProvisioningRequest request = new ProvisioningRequest();
+        request.setVariables(new HashMap<>());
+        ProvisioningResult result = new ProvisioningResult(request);
+        ProvisioningContext context = new ProvisioningContext(request, result);
+        assertEquals(
+                "trino.jar",
+                targetArtifactFileName(context, new ProvisioArtifact("io.trinodb:trino-main:445"), "trino.jar"));
+        assertEquals(
+                "trino-main-445.jar",
+                targetArtifactFileName(
+                        context, new ProvisioArtifact("io.trinodb:trino-main:455"), "trino-main-445.jar"));
+        assertEquals(
+                "org.wso2.carbon.identity.user.store.configuration.stub-7.4.15.jar",
+                targetArtifactFileName(
+                        context,
+                        new ProvisioArtifact(
+                                "org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.stub:7.4.15"),
+                        "org.wso2.carbon.identity.user.store.configuration.stub-7.4.15.jar"));
+        assertEquals(
+                "org.wso2.carbon.user.mgt.ui-7.4.15.jar",
+                targetArtifactFileName(
+                        context,
+                        new ProvisioArtifact("org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.ui:7.4.15"),
+                        "org.wso2.carbon.user.mgt.ui-7.4.15.jar"));
+    }
+
+    @Test
+    public void validateArtifactFilenames_GA() {
+        ProvisioningRequest request = new ProvisioningRequest();
+        request.setVariables(new HashMap<>());
+        request.getVariables()
+                .put(
+                        ProvisioVariables.FALLBACK_TARGET_FILE_NAME_MODE,
+                        ProvisioVariables.FallBackTargetFileNameMode.GA.name());
+        ProvisioningResult result = new ProvisioningResult(request);
+        ProvisioningContext context = new ProvisioningContext(request, result);
         assertEquals(
                 "io.trinodb_trino.jar",
-                targetArtifactFileName(new ProvisioArtifact("io.trinodb:trino-main:445"), "trino.jar"));
+                targetArtifactFileName(context, new ProvisioArtifact("io.trinodb:trino-main:445"), "trino.jar"));
         assertEquals(
                 "io.trinodb_trino-main-445.jar",
-                targetArtifactFileName(new ProvisioArtifact("io.trinodb:trino-main:455"), "trino-main-445.jar"));
+                targetArtifactFileName(
+                        context, new ProvisioArtifact("io.trinodb:trino-main:455"), "trino-main-445.jar"));
         assertEquals(
                 "org.wso2.carbon.identity.user.s....configuration.stub-7.4.15.jar",
                 targetArtifactFileName(
+                        context,
                         new ProvisioArtifact(
                                 "org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.stub:7.4.15"),
                         "org.wso2.carbon.identity.user.store.configuration.stub-7.4.15.jar"));
         assertEquals(
                 "org.wso2.ca...y.framework_org.wso2.carbon.user.mgt.ui-7.4.15.jar",
                 targetArtifactFileName(
+                        context,
                         new ProvisioArtifact("org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.ui:7.4.15"),
                         "org.wso2.carbon.user.mgt.ui-7.4.15.jar"));
     }

--- a/provisio-its/pom.xml
+++ b/provisio-its/pom.xml
@@ -102,16 +102,20 @@
       <artifactId>maven-resolver-supplier</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.takari</groupId>
       <artifactId>takari-archiver</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/provisio-maven-plugin/pom.xml
+++ b/provisio-maven-plugin/pom.xml
@@ -51,6 +51,14 @@
       <version>${incrementalbuild.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
@@ -58,11 +66,6 @@
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ProvisioningIntegrationTest.java
+++ b/provisio-maven-plugin/src/test/java/ca/vanzyl/maven/plugins/provisio/ProvisioningIntegrationTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.6.3", "3.8.8", "3.9.6"})
+@MavenVersions({"3.6.3", "3.8.8", "3.9.9"})
 @SuppressWarnings({"JUnitTestNG", "PublicField"})
 public class ProvisioningIntegrationTest {
     @Rule
@@ -50,15 +50,25 @@ public class ProvisioningIntegrationTest {
                 .assertErrorFreeLog();
 
         File libdir = new File(basedir, "target/test-1.0/lib");
-        assertTrue("guice exists", new File(libdir, "com.google.inject_guice-7.0.0.jar").isFile());
-        assertTrue("guava exists", new File(libdir, "com.google.guava_guava-31.0.1-jre.jar").isFile());
-        assertFalse("slf4j-api not exists", new File(libdir, "org.slf4j_slf4j-api-2.0.11.jar").isFile());
-        assertTrue("slf4j-simple exists", new File(libdir, "org.slf4j_slf4j-simple-2.0.11.jar").isFile());
+        assertTrue("guice exists", new File(libdir, "guice-7.0.0.jar").isFile());
+        assertTrue("guava exists", new File(libdir, "guava-31.0.1-jre.jar").isFile());
+        assertFalse("slf4j-api not exists", new File(libdir, "slf4j-api-2.0.11.jar").isFile());
+        assertTrue("slf4j-simple exists", new File(libdir, "slf4j-simple-2.0.11.jar").isFile());
     }
 
     @Test
     public void testConflictingArtifacts() throws Exception {
         File basedir = resources.getBasedir("conflicting-filenames");
+        maven.forProject(basedir)
+                .withCliOption("-X")
+                .execute("provisio:provision")
+                .assertLogText("Conflict:")
+                .assertLogText("would overwrite existing file");
+    }
+
+    @Test
+    public void testConflictingArtifactsGA() throws Exception {
+        File basedir = resources.getBasedir("conflicting-filenames-ga");
         maven.forProject(basedir)
                 .withCliOption("-X")
                 .execute("provisio:provision")

--- a/provisio-maven-plugin/src/test/projects/conflicting-filenames-ga/pom.xml
+++ b/provisio-maven-plugin/src/test/projects/conflicting-filenames-ga/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ca.vanzyl.provisio.maven.plugins.its</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <packaging>provisio</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <provisio.fallbackTargetFileNameMode>GA</provisio.fallbackTargetFileNameMode>
+    </properties>
+
+    <dependencies>
+        <!-- ideally artifacts should not have the same artifactId and version but conflicts can happen -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.27.0-alpha</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.27.0-alpha</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>${it-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/provisio-maven-plugin/src/test/projects/conflicting-filenames-ga/src/main/provisio/provisio.xml
+++ b/provisio-maven-plugin/src/test/projects/conflicting-filenames-ga/src/main/provisio/provisio.xml
@@ -1,0 +1,3 @@
+<runtime>
+    <artifactSet to="/lib" ref="runtime.classpath" />
+</runtime>


### PR DESCRIPTION
Original issue: Provisio was silently overwriting conflicting target files.

Changes:
* this continues on change 3622ba8f2e0a308e703abac5bb0df531728e0219
* remove commons-lang3 (inline that single method)
* introduce ProvisioVariables helper class w/ rudimentary "config" support
* introduce config: allowTargetOverwrite (def false) - this is breaking change and will break builds that already have conflicting files
* introduce config: fallbackTargetFileNameMode - this reverts to "normal" state, using resolved file name, but keeps @wendigo change of "GA".
* etc