### PR TITLE
ZIP archives are TZ and DST dependant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <surefire.runOrder>alphabetical</surefire.runOrder>
     <surefire.mem>-Xmx256m</surefire.mem>
     <mavenVersion>3.9.9</mavenVersion>
-    <takariArchiverVersion>1.0.2</takariArchiverVersion>
+    <takariArchiverVersion>1.0.3</takariArchiverVersion>
     <!-- Align with Aether version used in $mavenVersion -->
     <aetherVersion>1.9.22</aetherVersion>
     <!-- Align with Sisu version used in $mavenVersion -->


### PR DESCRIPTION
Despite "normalization", the ZIP archive entries will still not be reproducible only with original TZ and DST.

Fix is to upgrade to takari-archiver 1.0.3