### PR TITLE
Upgrading from okhttp to okhttp3 because of CVE-2023-3635 and EOL

### DIFF
--- a/provisio-core/pom.xml
+++ b/provisio-core/pom.xml
@@ -75,9 +75,9 @@
       <artifactId>provisio-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>2.7.5</version>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-jvm</artifactId>
+      <version>5.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/SimpleProvisioner.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/SimpleProvisioner.java
@@ -16,16 +16,16 @@
 package ca.vanzyl.provisio;
 
 import ca.vanzyl.provisio.archive.UnArchiver;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.ResponseBody;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 public abstract class SimpleProvisioner {
 


### PR DESCRIPTION
Upgrading from okhttp to okhttp3 because of CVE-2023-3635 and EOL