### PR TITLE
Support filtering for fileSet directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ What follows are various techniques and capabilities for building runtimes. Prov
     <directory path="${basedir}/src/main/etc">
       <include>**/*.properties</include>
     </directory>
+    <directory path="${basedir}/src/main/etc" filtering="true">
+      <include>runtime.properties</include>
+    </directory>
+    <directory path="${basedir}/src/main/etc" mustache="true">
+      <include>jvm.config</include>
+    </directory>
   </fileSet>
 </runtime>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -110,17 +110,17 @@
       <dependency>
         <groupId>ca.vanzyl</groupId>
         <artifactId>provisio-core</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>ca.vanzyl</groupId>
         <artifactId>provisio-model</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>ca.vanzyl</groupId>
         <artifactId>provisio-maven</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>io.takari</groupId>

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/MavenProvisioner.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/MavenProvisioner.java
@@ -19,6 +19,9 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import ca.vanzyl.provisio.action.artifact.WriteToDiskAction;
+import ca.vanzyl.provisio.action.artifact.filter.MustacheFilteringProcessor;
+import ca.vanzyl.provisio.action.artifact.filter.StandardFilteringProcessor;
+import ca.vanzyl.provisio.archive.UnarchivingEnhancedEntryProcessor;
 import ca.vanzyl.provisio.model.ArtifactSet;
 import ca.vanzyl.provisio.model.Directory;
 import ca.vanzyl.provisio.model.FileSet;
@@ -31,9 +34,12 @@ import ca.vanzyl.provisio.model.Resource;
 import ca.vanzyl.provisio.model.ResourceSet;
 import ca.vanzyl.provisio.model.Runtime;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -583,13 +589,14 @@ public class MavenProvisioner {
                 for (Directory directory : fileSet.getDirectories()) {
                     File sourceDirectory = new File(directory.getPath());
                     File targetDirectory = new File(context.getRequest().getOutputDirectory(), fileSet.getDirectory());
-                    copyDirectoryStructure(sourceDirectory, targetDirectory, directory);
+                    copyDirectoryStructure(sourceDirectory, targetDirectory, directory, context);
                 }
             }
         }
     }
 
-    private void copyDirectoryStructure(File sourceDirectory, File targetDirectory, Directory directory)
+    private void copyDirectoryStructure(
+            File sourceDirectory, File targetDirectory, Directory directory, ProvisioningContext context)
             throws IOException {
         List<String> includes = directory.getIncludes();
         List<String> excludes = directory.getExcludes();
@@ -607,14 +614,14 @@ public class MavenProvisioner {
             List<File> paths = FileUtils.getFiles(sourceDirectory, includesString, excludesString);
             for (File source : paths) {
                 File target = new File(targetDirectory, source.getName());
-                copy(source, target);
+                copy(source, target, directory, context);
             }
         } else {
             List<String> relativePaths = FileUtils.getFileNames(sourceDirectory, includesString, excludesString, false);
             for (String relativePath : relativePaths) {
                 File source = new File(sourceDirectory, relativePath);
                 File target = new File(targetDirectory, relativePath);
-                copy(source, target);
+                copy(source, target, directory, context);
             }
         }
     }
@@ -628,6 +635,43 @@ public class MavenProvisioner {
                 target.toPath(),
                 StandardCopyOption.COPY_ATTRIBUTES,
                 StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void copy(File source, File target, Directory directory, ProvisioningContext context) throws IOException {
+        copy(source, target, directory.isFiltering(), directory.isMustache(), context);
+    }
+
+    private void copy(File source, File target, boolean filtering, boolean mustache, ProvisioningContext context)
+            throws IOException {
+        if (filtering && mustache) {
+            throw new RuntimeException("Only one of filtering or mustache can be enabled for " + source);
+        }
+        if (filtering) {
+            copy(source, target, new StandardFilteringProcessor(context.getVariables()));
+            return;
+        }
+        if (mustache) {
+            copy(source, target, new MustacheFilteringProcessor(context.getVariables()));
+            return;
+        }
+        copy(source, target);
+    }
+
+    private void copy(File source, File target, UnarchivingEnhancedEntryProcessor processor) throws IOException {
+        if (!target.getParentFile().exists()) {
+            target.getParentFile().mkdirs();
+        }
+        try (FileInputStream input = new FileInputStream(source);
+                FileOutputStream output = new FileOutputStream(target)) {
+            processor.processStream(source.getName(), input, output);
+        }
+        target.setLastModified(source.lastModified());
+        try {
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(source.toPath());
+            Files.setPosixFilePermissions(target.toPath(), permissions);
+        } catch (UnsupportedOperationException ignored) {
+            // Not all filesystems expose POSIX permissions.
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/filter/MustacheFilteringProcessor.java
+++ b/provisio-core/src/main/java/ca/vanzyl/provisio/action/artifact/filter/MustacheFilteringProcessor.java
@@ -25,14 +25,15 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.HashMap;
 import java.util.Map;
 
 public class MustacheFilteringProcessor implements UnarchivingEnhancedEntryProcessor {
 
-    private final Map<String, String> variables;
+    private final Map<String, Object> variables;
 
     public MustacheFilteringProcessor(Map<String, String> variables) {
-        this.variables = variables;
+        this.variables = mustacheVariables(variables);
     }
 
     @Override
@@ -42,5 +43,20 @@ public class MustacheFilteringProcessor implements UnarchivingEnhancedEntryProce
         Mustache mustache = mf.compile(new InputStreamReader(inputStream), "provisio");
         mustache.execute(writer, variables);
         writer.flush();
+    }
+
+    private Map<String, Object> mustacheVariables(Map<String, String> variables) {
+        Map<String, Object> mustacheVariables = new HashMap<>();
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            String value = entry.getValue();
+            if ("true".equalsIgnoreCase(value)) {
+                mustacheVariables.put(entry.getKey(), Boolean.TRUE);
+            } else if ("false".equalsIgnoreCase(value)) {
+                mustacheVariables.put(entry.getKey(), Boolean.FALSE);
+            } else {
+                mustacheVariables.put(entry.getKey(), value);
+            }
+        }
+        return mustacheVariables;
     }
 }

--- a/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
+++ b/provisio-its/src/test/java/ca/vanzyl/provisio/its/ProvisioTest.java
@@ -152,6 +152,73 @@ public class ProvisioTest {
     }
 
     @Test
+    public void validateUnpackWithMustacheConditionalEnabled() throws Exception {
+        // A {{#datadog}} section renders when the datadog variable is present and non-empty.
+        String name = "it-0022";
+        deleteOutputDirectory(name);
+        Map<String, String> variables = new HashMap<>();
+        variables.put("datadog", "true");
+        variables.put("ddAgentPath", "/opt/datadog/dd-java-agent.jar");
+        variables.put("ddService", "server");
+        ProvisioningResult result = provision(name, variables);
+        assertFileExists(result, "etc/jvm.config");
+        String config = FileUtils.fileRead(file(result.getOutputDirectory(), "etc/jvm.config"));
+        assertTrue("base JVM options are always present", config.contains("-Xmx16G"));
+        assertTrue(
+                "datadog javaagent is rendered with a raw (unescaped) path",
+                config.contains("-javaagent:/opt/datadog/dd-java-agent.jar"));
+        assertTrue("datadog service property is rendered", config.contains("-Ddd.service=server"));
+    }
+
+    @Test
+    public void validateUnpackWithMustacheConditionalDisabled() throws Exception {
+        // Omitting the datadog variable leaves the {{#datadog}} section unrendered.
+        String name = "it-0022";
+        deleteOutputDirectory(name);
+        ProvisioningResult result = provision(name);
+        assertFileExists(result, "etc/jvm.config");
+        String config = FileUtils.fileRead(file(result.getOutputDirectory(), "etc/jvm.config"));
+        assertTrue("base JVM options are always present", config.contains("-Xmx16G"));
+        assertFalse(
+                "datadog javaagent must not be rendered when the variable is absent", config.contains("-javaagent"));
+        assertFalse("datadog service property must not be rendered", config.contains("-Ddd.service"));
+    }
+
+    @Test
+    public void validateDirectoryMustacheRuntimeConfig() throws Exception {
+        String name = "it-0023";
+        deleteOutputDirectory(name);
+        ProvisioningResult result = provision(name);
+        assertFileExists(result, "etc/config.properties");
+        assertFileExists(result, "etc/annotations.properties");
+        assertFileExists(result, "etc/jvm.config");
+        String properties = FileUtils.fileRead(file(result.getOutputDirectory(), "etc/config.properties"));
+        assertTrue(properties.contains("http-server.http.port=8080"));
+        assertTrue(properties.contains("node.environment=development"));
+        String annotations = FileUtils.fileRead(file(result.getOutputDirectory(), "etc/annotations.properties"));
+        assertTrue(annotations.contains("service_name=${ENV:SERVICE_NAME}"));
+        String config = FileUtils.fileRead(file(result.getOutputDirectory(), "etc/jvm.config"));
+        assertTrue(config.contains("-XX:MaxRAMPercentage=80"));
+        assertFalse(config.contains("-javaagent"));
+
+        deleteOutputDirectory(name);
+        Map<String, String> variables = new HashMap<>();
+        variables.put("datadog", "false");
+        result = provision(name, variables);
+        config = FileUtils.fileRead(file(result.getOutputDirectory(), "etc/jvm.config"));
+        assertTrue(config.contains("-XX:MaxRAMPercentage=80"));
+        assertFalse(config.contains("-javaagent"));
+
+        deleteOutputDirectory(name);
+        variables.put("datadog", "true");
+        result = provision(name, variables);
+        config = FileUtils.fileRead(file(result.getOutputDirectory(), "etc/jvm.config"));
+        assertTrue(config.contains("-XX:MaxRAMPercentage=80"));
+        assertTrue(config.contains("-javaagent:/opt/lib/dd-java-agent.jar"));
+        assertTrue(config.contains("-Ddd.service.name=server"));
+    }
+
+    @Test
     public void validateMakeDirectoryAction() throws Exception {
         String name = "it-0021";
         deleteOutputDirectory(name);

--- a/provisio-its/src/test/runtimes/it-0022/README.md
+++ b/provisio-its/src/test/runtimes/it-0022/README.md
@@ -1,0 +1,14 @@
+Validating conditional Mustache filtering: a `jvm.config` template carries a
+`{{#datadog}}...{{/datadog}}` section that is rendered only when `datadog` is
+true. This is the pattern for toggling optional agent properties on at
+provisioning time.
+
+``` xml
+<runtime>
+  <artifactSet to="etc">
+    <artifact id="io.takari.provisio.its:it-0022:0.0.1-SNAPSHOT">
+      <unpack mustache="true" includes="jvm.config" />
+    </artifact>
+  </artifactSet>
+</runtime>
+```

--- a/provisio-its/src/test/runtimes/it-0022/prereq/pom.xml
+++ b/provisio-its/src/test/runtimes/it-0022/prereq/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.takari.provisio.its</groupId>
+  <artifactId>it-0022</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <description>A JAR file containing a jvm.config Mustache template with a conditional section</description>
+</project>

--- a/provisio-its/src/test/runtimes/it-0022/prereq/src/main/resources/jvm.config
+++ b/provisio-its/src/test/runtimes/it-0022/prereq/src/main/resources/jvm.config
@@ -1,0 +1,6 @@
+-server
+-Xmx16G
+{{#datadog}}
+-javaagent:{{{ddAgentPath}}}
+-Ddd.service={{{ddService}}}
+{{/datadog}}

--- a/provisio-its/src/test/runtimes/it-0022/provisio.xml
+++ b/provisio-its/src/test/runtimes/it-0022/provisio.xml
@@ -1,0 +1,7 @@
+<runtime>
+  <artifactSet to="etc">
+    <artifact id="io.takari.provisio.its:it-0022:0.0.1-SNAPSHOT">
+      <unpack mustache="true" includes="jvm.config" />
+    </artifact>
+  </artifactSet>
+</runtime>

--- a/provisio-its/src/test/runtimes/it-0023/README.md
+++ b/provisio-its/src/test/runtimes/it-0023/README.md
@@ -1,0 +1,15 @@
+Validating Mustache filtering on a fileSet directory. This lets a runtime
+descriptor copy selected runtime config directly instead of pre-rendering it
+into `target/generated-provisio`.
+
+``` xml
+<runtime>
+  <fileSet to="etc">
+    <directory path="${basedir}/src/main/resources" mustache="true">
+      <include>config.properties</include>
+      <include>annotations.properties</include>
+      <include>jvm.config</include>
+    </directory>
+  </fileSet>
+</runtime>
+```

--- a/provisio-its/src/test/runtimes/it-0023/provisio.xml
+++ b/provisio-its/src/test/runtimes/it-0023/provisio.xml
@@ -1,0 +1,9 @@
+<runtime>
+  <fileSet to="etc">
+    <directory path="${basedir}/src/main/resources" mustache="true">
+      <include>config.properties</include>
+      <include>annotations.properties</include>
+      <include>jvm.config</include>
+    </directory>
+  </fileSet>
+</runtime>

--- a/provisio-its/src/test/runtimes/it-0023/provisio.yaml
+++ b/provisio-its/src/test/runtimes/it-0023/provisio.yaml
@@ -1,0 +1,9 @@
+fileSets:
+  - to: etc
+    directories:
+      - path: ${basedir}/src/main/resources
+        mustache: true
+        includes:
+          - config.properties
+          - annotations.properties
+          - jvm.config

--- a/provisio-its/src/test/runtimes/it-0023/src/main/resources/annotations.properties
+++ b/provisio-its/src/test/runtimes/it-0023/src/main/resources/annotations.properties
@@ -1,0 +1,1 @@
+service_name=${ENV:SERVICE_NAME}

--- a/provisio-its/src/test/runtimes/it-0023/src/main/resources/config.properties
+++ b/provisio-its/src/test/runtimes/it-0023/src/main/resources/config.properties
@@ -1,0 +1,2 @@
+http-server.http.port=8080
+node.environment=development

--- a/provisio-its/src/test/runtimes/it-0023/src/main/resources/jvm.config
+++ b/provisio-its/src/test/runtimes/it-0023/src/main/resources/jvm.config
@@ -1,0 +1,9 @@
+-XX:InitialRAMPercentage=80
+-XX:MaxRAMPercentage=80
+-XX:+ExitOnOutOfMemoryError
+-Dfile.encoding=UTF-8
+{{#datadog}}
+-javaagent:/opt/lib/dd-java-agent.jar
+-Ddd.service.name=server
+-Ddd.profiling.enabled=true
+{{/datadog}}

--- a/provisio-model/src/main/java/ca/vanzyl/provisio/model/Directory.java
+++ b/provisio-model/src/main/java/ca/vanzyl/provisio/model/Directory.java
@@ -24,6 +24,8 @@ public class Directory {
     private List<String> includes;
     private List<String> excludes;
     private boolean flatten;
+    private boolean filtering;
+    private boolean mustache;
 
     public String getPath() {
         return path;
@@ -53,5 +55,21 @@ public class Directory {
 
     public void setFlatten(boolean flatten) {
         this.flatten = flatten;
+    }
+
+    public boolean isFiltering() {
+        return filtering;
+    }
+
+    public void setFiltering(boolean filtering) {
+        this.filtering = filtering;
+    }
+
+    public boolean isMustache() {
+        return mustache;
+    }
+
+    public void setMustache(boolean mustache) {
+        this.mustache = mustache;
     }
 }

--- a/provisio-model/src/main/java/ca/vanzyl/provisio/model/io/RuntimeReader.java
+++ b/provisio-model/src/main/java/ca/vanzyl/provisio/model/io/RuntimeReader.java
@@ -110,6 +110,8 @@ public class RuntimeReader {
         xstream.addImplicitCollection(Directory.class, "includes", "include", String.class);
         xstream.addImplicitCollection(Directory.class, "excludes", "exclude", String.class);
         xstream.useAttributeFor(Directory.class, "flatten");
+        xstream.useAttributeFor(Directory.class, "filtering");
+        xstream.useAttributeFor(Directory.class, "mustache");
 
         xstream.registerConverter(new RuntimeConverter());
         xstream.registerConverter(new ArtifactConverter());

--- a/provisio-model/src/test/java/ca/vanzyl/provisio/model/RuntimeReaderTest.java
+++ b/provisio-model/src/test/java/ca/vanzyl/provisio/model/RuntimeReaderTest.java
@@ -281,8 +281,12 @@ public class RuntimeReaderTest {
                 "${basedir}/src/main/etc/config.properties",
                 fileSet.getFiles().get(1).getPath());
         assertEquals("${basedir}/src/main/etc", fileSet.getDirectories().get(0).getPath());
+        assertTrue(fileSet.getDirectories().get(0).isFiltering());
         assertEquals(
                 "**/*.properties", fileSet.getDirectories().get(0).getIncludes().get(0));
+        assertEquals("${basedir}/src/main/etc", fileSet.getDirectories().get(1).getPath());
+        assertTrue(fileSet.getDirectories().get(1).isMustache());
+        assertEquals("jvm.config", fileSet.getDirectories().get(1).getIncludes().get(0));
     }
 
     @Test

--- a/provisio-model/src/test/runtimes/it-0002/provisio.xml
+++ b/provisio-model/src/test/runtimes/it-0002/provisio.xml
@@ -2,8 +2,11 @@
   <fileSet to="/etc">
     <file path="${basedir}/src/main/etc/jvm.config"/>
     <file path="${basedir}/src/main/etc/config.properties"/>
-    <directory path="${basedir}/src/main/etc">
+    <directory path="${basedir}/src/main/etc" filtering="true">
       <include>**/*.properties</include>
+    </directory>
+    <directory path="${basedir}/src/main/etc" mustache="true">
+      <include>jvm.config</include>
     </directory>
   </fileSet>
 </runtime>


### PR DESCRIPTION
## Summary

`fileSet` directory entries can now opt into template processing while copying selected files from a directory:

- `filtering="true"` uses the existing Maven-style `${...}` interpolation.
- `mustache="true"` uses the existing Mustache `{{...}}` renderer, including conditional sections.

The main runtime-config shape is one `fileSet` with one filtered directory entry, for example:

```xml
<fileSet to="etc">
  <directory path="${basedir}/src/main/resources" mustache="true">
    <include>config.properties</include>
    <include>annotations.properties</include>
    <include>jvm.config</include>
  </directory>
</fileSet>
```

The integration fixture also includes a sibling YAML comparison file for the same shape.

This keeps descriptor authors from pre-rendering runtime config into generated directories while preserving the existing distinction between standard filtering and Mustache rendering. Boolean-like Mustache variables are coerced so `name=false` behaves as false for sections.

The change also keeps internal module dependency management on the current project version so reactor tests exercise the code under change.

## Tests

- `./mvnw -pl provisio-model -Dtest=RuntimeReaderTest#validateFileSetToAttributeIsUsed test`
- `./mvnw -pl provisio-its -am -Dtest=ProvisioTest#validateDirectoryMustacheRuntimeConfig -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl provisio-its -am -Dtest=ProvisioTest#validateUnpackWithMustacheConditionalEnabled+validateUnpackWithMustacheConditionalDisabled -Dsurefire.failIfNoSpecifiedTests=false test`

## GitHub

- Verify / Build and Test on JDK 17: passed
- Verify / Build and Test on JDK 21: passed
- Verify / Build and Test on JDK 25: passed
